### PR TITLE
fix warnings

### DIFF
--- a/src/c/DW_banded.c
+++ b/src/c/DW_banded.c
@@ -93,7 +93,7 @@ d_path_data2 * get_dpath_idx( seq_coor_t d, seq_coor_t k, unsigned long max_idx,
 void print_d_path(  d_path_data2 * base, unsigned long max_idx) {
     unsigned long idx;
     for (idx = 0; idx < max_idx; idx++){
-        printf("dp %ld %ld %ld %ld %ld %ld %ld %ld\n",idx, (base+idx)->d, (base+idx)->k, (base+idx)->x1, (base+idx)->y1, (base+idx)->x2, (base+idx)->y2, (base+idx)->pre_k);
+        printf("dp %ld %d %d %d %d %d %d %d\n",idx, (base+idx)->d, (base+idx)->k, (base+idx)->x1, (base+idx)->y1, (base+idx)->x2, (base+idx)->y2, (base+idx)->pre_k);
     }
 }
 
@@ -169,7 +169,7 @@ alignment * align(char * query_seq, seq_coor_t q_len,
  
         for (k = min_k; k <= max_k;  k += 2) {
 
-            if ( k == min_k || k != max_k && V[ k - 1 + k_offset ] < V[ k + 1 + k_offset] ) {
+            if ( k == min_k || (k != max_k && V[ k - 1 + k_offset ]) < V[ k + 1 + k_offset] ) {
                 pre_k = k + 1;
                 x = V[ k + 1 + k_offset];
             } else {

--- a/src/c/common.h
+++ b/src/c/common.h
@@ -151,6 +151,7 @@ kmer_match * find_kmer_pos_for_seq( char *,
                                     seq_addr_array, 
                                     kmer_lookup * );
 
+void free_kmer_match( kmer_match * ptr);
 void free_kmer_lookup(kmer_lookup * );
 
 

--- a/src/c/kmer_lookup.c
+++ b/src/c/kmer_lookup.c
@@ -70,7 +70,6 @@ int compare_seq_coor(const void * a, const void * b) {
 
 kmer_lookup * allocate_kmer_lookup ( seq_coor_t size ) {
     kmer_lookup * kl;
-    seq_coor_t i;
 
     //printf("%lu is allocated for kmer lookup\n", size);
     kl = (kmer_lookup *)  malloc( size * sizeof(kmer_lookup) );
@@ -310,10 +309,6 @@ aln_range* find_best_aln_range(kmer_match * km_ptr,
     long int max_k_mer_count;
     long int max_k_mer_bin;
     seq_coor_t cur_start;
-    seq_coor_t cur_pos;
-    seq_coor_t max_start;
-    seq_coor_t max_end;
-    seq_coor_t kmer_dist;
 
     arange = calloc(1 , sizeof(aln_range));
 


### PR DESCRIPTION
We still have these 3 to address:
```
src/c/falcon.c: In function ‘get_cns_from_align_tags’:
src/c/falcon.c:522:28: warning: ‘bb’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             cns_str[index] = bb;
                            ^
src/c/falcon.c:367:26: warning: ‘base’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             unsigned int base;
                          ^
src/c/falcon.c:360:34: warning: ‘t_pos’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (delta > msa_array[t_pos]->max_delta) {
```