### PR TITLE
Notify if 'done' job is incomplete

### DIFF
--- a/src/py_scripts/fc_run.py
+++ b/src/py_scripts/fc_run.py
@@ -88,12 +88,25 @@ def run_script(job_data, job_type = "SGE" ):
                                                script=script_fn)
 
         fc_run_logger.info( "submitting %s for SGE, start job: %s " % (script_fn, job_name) )
-        os.system( sge_cmd )
+        cmd = sge_cmd
+        rc = os.system(cmd)
     elif job_type == "local":
         script_fn = job_data["script_fn"]
         job_name = job_data["job_name"]
-        fc_run_logger.info( "executing %s locally, start job: %s " % (script_fn, job_name) )
-        os.system( "bash %s" % script_fn )
+        fc_run_logger.info( "executing %r locally, start job: %r " % (script_fn, job_name) )
+        cmd = "bash %s" % script_fn
+        rc = os.system(cmd)
+    if rc:
+        msg = "Cmd %r (job %r) returned %d." % (cmd, job_name, rc)
+        fc_run_logger.info(msg)
+        # For non-qsub, this might still help with debugging. But technically
+        # we should not raise here, as a failure should be noticed later.
+        # When we are confident that script failures are handled well,
+        # we can make this optional.
+        raise Exception(msg)
+    else:
+        msg = "Cmd %r (job %r) returned %d" % (cmd, job_name, rc)
+        fc_run_logger.debug(msg)
 
 def wait_for_file(filename, task = None, job_name = ""):
     while 1:


### PR DESCRIPTION
`set -e` is good for stopping the job early. However, we still wait for the `.done` file, since that is the only way we have to receive a message from a distributed job.

With this change, the job will still create the `.done` file always, but it will remove a new `.done.incomplete` file *only* if there was no error. That lets us stop quickly.

TODO: Possibly, we need to trap exceptions somewhere and delete running jobs.

For local jobs, we turn job failures into exceptions, which helps debugging though it is not strictly necessary.

TODO: When we are comfortable that we handle failures well, we can raise the Exception optionally, so the local flow will match the distributed flow by default.