### PR TITLE
use GMT for logging

### DIFF
--- a/src/py_scripts/fc_run.py
+++ b/src/py_scripts/fc_run.py
@@ -648,6 +648,8 @@ format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 def setup_logger(logging_config_fn):
     """See https://docs.python.org/2/library/logging.config.html
     """
+    logging.Formatter.converter = time.gmtime # cannot be done in .ini
+
     if logging_config_fn:
         logger_fileobj = open(logging_config_fn)
     else:


### PR DESCRIPTION
aklammer@ says:
> 423, 424 – All logging should be in UTC, and include appropriate context

* http://bugzilla.nanofluidics.com/show_bug.cgi?id=26699
* http://stackoverflow.com/questions/12139648/python-logging-specifying-converter-attribute-of-a-log-formatter-in-config-file
* http://stackoverflow.com/questions/6321160/python-logging-how-to-set-time-to-gmt
* https://docs.python.org/2/library/logging.html#logging.Formatter.formatTime