### PR TITLE
Proper ext_modules; Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# Build matrix / environment variable are explained on:
+# http://about.travis-ci.org/docs/user/build-configuration/
+# This file can be validated on:
+# http://lint.travis-ci.org/
+
+#before_install: sudo apt-get install -y cmake
+# cmake is pre-installed in Travis for both linux and osx
+
+#before_install:
+#  - sudo apt-get update -qq
+#  - sudo apt-get install -qq valgrind
+#sudo: required
+os:
+  - linux
+language: python
+compiler:
+  - clang  # hmm. distutils uses 'gcc' anyway
+#  - gcc
+script: ./travis.sh
+#env:
+#  matrix:
+#    - SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false
+#    - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
+notifications:
+  email: false

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+#from setuptools import setup
 
-from distutils.core import Extension
+from distutils.core import Extension, setup
+#from distutils.command.build_clib import build_clib
 
 import glob
 
+#libfalcon = ('falcon', {'sources': ['src/c/DW_banded.c', 'src/c/kmer_lookup.c', 'src/c/falcon.c']})
 
 #install_requires=[ "pbcore >= 0.6.3", "networkx >= 1.7" ]
 install_requires=[ "networkx >= 1.7" ]
@@ -19,12 +21,11 @@ setup(name='falcon_kit',
       author_email='jchin@pacificbiosciences.com',
       packages=['falcon_kit'],
       package_dir={'falcon_kit':'src/py/'},
-      ext_modules=[Extension('falcon_kit.DW_align', ['src/c/DW_banded.c'], 
-                   extra_link_args=["-fPIC",  "-O3"]),
-                   Extension('falcon_kit.kmer_lookup', ['src/c/kmer_lookup.c'],
-                   extra_link_args=["-fPIC",  "-O3"]),
-                   Extension('falcon_kit.falcon', ['src/c/DW_banded.c', 'src/c/kmer_lookup.c', 'src/c/falcon.c'],
-                   extra_link_args=["-fPIC",  "-O3"]),
+      #libraries=[libfalcon],
+      #cmdclass = {'build_clib': build_clib},
+      ext_modules=[
+                   Extension('falcon_kit.ext_falcon', ['src/c/ext_falcon.c', 'src/c/DW_banded.c', 'src/c/kmer_lookup.c', 'src/c/falcon.c'],
+                    extra_link_args=["-fPIC",  "-O3"]),
                    ],
       scripts = scripts,
       zip_safe = False,

--- a/src/c/ext_falcon.c
+++ b/src/c/ext_falcon.c
@@ -1,0 +1,13 @@
+#include "Python.h"
+static PyMethodDef SpamMethods[] = {
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+PyMODINIT_FUNC
+initext_falcon(void)
+{
+    PyObject *m;
+
+    m = Py_InitModule("falcon_kit.ext_falcon", SpamMethods);
+    if (m == NULL)
+        return;
+}

--- a/src/py/FastaReader.py
+++ b/src/py/FastaReader.py
@@ -235,11 +235,11 @@ class FastaReader(ReaderBase):
     over FastaRecord objects.  Agnostic about line wrapping.
     Example:
     .. doctest::
-        >>> from pbcore.io import FastaReader
-        >>> from pbcore import data
-        >>> filename = data.getTinyFasta()
-        >>> r = FastaReader(filename)
-        >>> for record in r:
+        TODO: Get data.
+        > from pbcore import data
+        > filename = data.getTinyFasta()
+        > r = FastaReader(filename)
+        > for record in r:
         ...     print record.name, len(record.sequence), record.md5
         ref000001|EGFR_Exon_2 183 e3912e9ceacd6538ede8c1b2adda7423
         ref000002|EGFR_Exon_3 203 4bf218da37175a91869033024ac8f9e9

--- a/src/py/falcon_kit.py
+++ b/src/py/falcon_kit.py
@@ -35,11 +35,15 @@
 # OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #################################################################################$$
-
+__all__ = [
+    'kup', 'DWA', 'falcon',
+    'KmerLookup', 'KmerMatch', 'AlnRange', 'ConsensusData',
+    'Alignment', 'get_alignment',
+    ]
 
 from ctypes import *
-import os
-module_path = os.path.split(__file__)[0]
+from . import ext_falcon
+#module_path = os.path.split(__file__)[0]
 
 
 seq_coor_t = c_int
@@ -66,7 +70,10 @@ class ConsensusData(Structure):
     _fields_ = [ ("sequence", c_char_p),
                  ("eff_cov", POINTER(c_uint)) ]
 
-kup = CDLL(os.path.join(module_path, "kmer_lookup.so"))
+
+falcon_dll = CDLL(ext_falcon.__file__)
+
+kup = falcon_dll
 
 kup.allocate_kmer_lookup.argtypes =  [seq_coor_t] 
 kup.allocate_kmer_lookup.restype = POINTER(KmerLookup)
@@ -121,14 +128,15 @@ class Alignment(Structure):
                  ("t_aln_str", c_char_p)]
 
 
-DWA = CDLL(os.path.join(module_path, "DW_align.so"))
+DWA = falcon_dll
+
 DWA.align.argtypes = [ POINTER(c_char), c_long, POINTER(c_char), c_long, c_long, c_int ] 
 DWA.align.restype = POINTER(Alignment)
 DWA.free_alignment.argtypes = [POINTER(Alignment)]
 
 
 
-falcon = CDLL(os.path.join(module_path,"falcon.so"))
+falcon = falcon_dll
 
 falcon.generate_consensus.argtypes = [POINTER(c_char_p), c_uint, c_uint, c_uint, c_uint, c_uint, c_double  ]
 falcon.generate_consensus.restype = POINTER(ConsensusData)

--- a/src/py_scripts/fc_consensus.py
+++ b/src/py_scripts/fc_consensus.py
@@ -37,17 +37,15 @@
 # SUCH DAMAGE.
 #################################################################################$$
 
-from ctypes import *
+from ctypes import (POINTER, c_char_p, c_uint, c_uint, c_uint, c_uint, c_uint, c_double, string_at)
 from falcon_kit.multiproc import Pool
+from falcon_kit import falcon
 import argparse
 import os
 import re
 import sys
 import falcon_kit
 
-module_path = falcon_kit.__path__[0]
-
-falcon = CDLL(os.path.join(module_path, "falcon.so"))
 
 falcon.generate_consensus.argtypes = [ POINTER(c_char_p), c_uint, c_uint, c_uint, c_uint, c_uint, c_double ]
 falcon.generate_consensus.restype = POINTER(falcon_kit.ConsensusData)

--- a/src/py_scripts/fc_run.py
+++ b/src/py_scripts/fc_run.py
@@ -867,6 +867,7 @@ def main(prog_name, input_config_fn, logger_config_fn=None):
         script.append("trap 'touch %s.exit' EXIT" % fn(self.falcon_asm_done))
         script.append( "source {install_prefix}/bin/activate".format(install_prefix = install_prefix) )
         script.append( "cd %s" % pread_dir )
+        # Write preads4falcon.fasta, in 1-preads_ovl:
         script.append( "DB2Falcon preads")
         script.append( "cd %s" % wd )
         script.append( """find %s/las_files -name "*.las" > las.fofn """ % pread_dir )
@@ -874,9 +875,9 @@ def main(prog_name, input_config_fn, logger_config_fn=None):
         length_cutoff_pr = config["length_cutoff_pr"]
         script.append( """fc_ovlp_filter.py --db %s --fofn las.fofn %s --min_len %d > preads.ovl""" %\
                 (fn(db_file), overlap_filtering_setting, length_cutoff_pr) )
-
         script.append( "ln -sf %s/preads4falcon.fasta ." % pread_dir)
         script.append( """fc_ovlp_to_graph.py preads.ovl --min_len %d > fc_ovlp_to_graph.log""" % length_cutoff_pr)
+        # Write 'p_ctg.fa' and 'a_ctg.fa':
         script.append( """fc_graph_to_contig.py""" )
         script.append( """touch %s""" % fn(self.falcon_asm_done))
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# -e: fail on error
+# -v: show commands
+# -x: show expanded commands
+set -vex
+
+#env | sort
+mkdir -p fc-env
+rm -f fc-env/bin/python
+virtualenv -p python2.7 fc-env || ../virtualenv/virtualenv.py fc-env
+. fc-env/bin/activate
+python setup.py -v install
+python -c 'import falcon_kit; print falcon_kit.falcon'
+
+# When doctests are passing, add this:
+#pip install nose
+#nosetests -v --with-doctest fc-env/lib/python2.7/site-packages/falcon_kit


### PR DESCRIPTION
## Proper ext_modules
By using the standard distutils.Extension, we can load the shared module more reliably. Then, `ctypes.CDLL` can operate on the `.so` (or `.dylib`) which was loaded by the extension module.

## Travis CI for FALCON:
This is passing in my repo:
* https://travis-ci.org/pb-cdunn/FALCON/builds

We just need somebody (mhsieh?) to enable it for PacificBiosciences/FALCON.

Also, all it does is build right now, which is better than nothing. But we can run unit-tests as we add them. You have to run 'nosetests' on the virtualenv installation because many modules depend on the shared libraries, but that's working fine.