### PR TITLE
New layout rules for oval_to_graph.py

### DIFF
--- a/src/py/mains/ovlp_to_graph.py
+++ b/src/py/mains/ovlp_to_graph.py
@@ -874,21 +874,28 @@ def construct_compound_paths(ug, u_edge_data):
                 start_node, end_node, bundle_edges, length, score, depth = data
                 compound_paths_0.append(  (start_node, "NA", end_node, 1.0*len(bundle_edges)/depth, length, score, bundle_edges ) )
 
-    compound_paths_0.sort( key=lambda x: -x[5] )
+    compound_paths_0.sort( key=lambda x: -len(x[6]) )
 
 
     edge_to_cpath = {}
     compound_paths_1 = {}
     for s, v, t, width, length, score, bundle_edges in compound_paths_0:
+        if DEBUG_LOG_LEVEL > 1:
+            print "constructing utg, test ", s,v, t
+        
         overlapped = False
         for vv, ww, kk in list(bundle_edges):
             if (vv, ww, kk) in edge_to_cpath:
+                if DEBUG_LOG_LEVEL > 1:
+                    print "remove overlapped utg", (s, v, t), (vv, ww, kk)
                 overlapped = True
                 break
             rvv = reverse_end(vv)
             rww = reverse_end(ww)
             rkk = reverse_end(kk)
-            if (vv, ww, kk) in edge_to_cpath:
+            if (rww, rvv, rkk) in edge_to_cpath:
+                if DEBUG_LOG_LEVEL > 1:
+                    print "remove overlapped r utg", (s, v, t),  (rww, rvv, rkk)
                 overlapped = True
                 break
             

--- a/src/py/mains/ovlp_to_graph.py
+++ b/src/py/mains/ovlp_to_graph.py
@@ -1150,6 +1150,10 @@ def main(*argv):
                     path_or_edges = "~".join( path_or_edges )
                 print >>f, s, v, t, type_, length, score, path_or_edges
 
+    # identify spurs in the utg graph
+    # Currently, we use ad-hoc logic filtering out shorter utg, but we ca
+    # add proper alignment comparison later to remove redundant utgs 
+
     utg_spurs = set()
     all_nodes = ug.nodes()
     excessive_link_nodes = set()
@@ -1299,9 +1303,6 @@ def main(*argv):
 
     ug = ug2
 
-    # identify spurs in the utg graph
-    # Currently, we use ad-hoc logic filtering out shorter utg, but we ca
-    # add proper alignment comparison later to remove redundant utgs 
 
 
     with open("utg_data","w") as f:

--- a/src/py/mains/ovlp_to_graph.py
+++ b/src/py/mains/ovlp_to_graph.py
@@ -1157,79 +1157,17 @@ def main(*argv):
 
     utg_spurs = set()
     all_nodes = ug.nodes()
-    excessive_link_nodes = set()
-
-    for n in all_nodes:
-        in_degree = len( set( e[0] for e in ug.in_edges(n))  ) # ignore mutli-edges
-        out_degree = len( set( e[1] for e in ug.out_edges(n)) )
-        if in_degree == 1 and out_degree == 1:
-            simple_nodes.add(n)
-        else:
-            if out_degree != 0:
-                s_nodes.add(n)
-            if in_degree != 0:
-                t_nodes.add(n)
-
-            if out_degree >= 2 and in_degree == 0:
-                excessive_link_nodes.add(n)
-            if in_degree >= 2 and out_degree == 0:
-                excessive_link_nodes.add(n)
-            if out_degree > 3 and in_degree < 2:
-                excessive_link_nodes.add(n)
-            if in_degree > 3 and out_degree < 2:
-                excessive_link_nodes.add(n)
-            if out_degree >= 3 and in_degree >= 3:
-                excessive_link_nodes.add(n)
-            if in_degree >= 3 and out_degree >= 3:
-                excessive_link_nodes.add(n)
-
-    spur_edges = set()
 
     ug2 = ug.copy()
+    spur_edges = set()
     edges_to_remove = set()
-
-    for n in list(excessive_link_nodes):
-        in_degree = len( set( e[0] for e in ug.in_edges(n))  ) # ignore mutli-edges
-        out_degree = len( set( e[1] for e in ug.out_edges(n)) )
-
-        for s, t, v in ug.in_edges(n, keys=True):
-            length, score, edges, type_ = u_edge_data[ (s, t, v) ]
-            if length > 30000:
-                continue
-            u_edge_data[ (s, t, v) ] = length, score, edges, "spur:1"
-            if DEBUG_LOG_LEVEL > 1:
-                print "spur:1", s,t,v, in_degree, out_degree
-            spur_edges.add( (s, t, v) )
-            edges_to_remove.add( (s, t, v) )
-            rs = reverse_end(t)
-            rt = reverse_end(s)
-            rv = reverse_end(v)
-            edges_to_remove.add( (rs, rt, rv) )
-            length, score, edges, type_ = u_edge_data[ (rs, rt, rv) ]
-            u_edge_data[ (rs, rt, rv) ] = length, score, edges, "spur:1"
-
-        for s, t, v in ug.out_edges(n, keys=True):
-            length, score, edges, type_ = u_edge_data[ (s, t, v) ]
-            if length > 30000:
-                continue
-            u_edge_data[ (s, t, v) ] = length, score, edges, "spur:1"
-            if DEBUG_LOG_LEVEL > 1:
-                print "spur:1", s,t,v, in_degree, out_degree
-            spur_edges.add( (s, t, v) )
-            edges_to_remove.add( (s, t, v) )
-            rs = reverse_end(t)
-            rt = reverse_end(s)
-            rv = reverse_end(v)
-            edges_to_remove.add( (rs, rt, rv) )
-            length, score, edges, type_ = u_edge_data[ (rs, rt, rv) ]
-            u_edge_data[ (rs, rt, rv) ] = length, score, edges, "spur:1"
 
     for n in s_nodes:
         if ug.in_degree(n) != 0:
             continue
         for s, t, v in ug.out_edges(n, keys=True):
             length, score, edges, type_ = u_edge_data[ (s, t, v) ]
-            if length > 30000:
+            if length > 50000 and len(edges) > 3:
                 continue
             in_degree = len( set( e[0] for e in ug.in_edges(t))  ) # ignore mutli-edges
             out_degree = len( set( e[1] for e in ug.out_edges(t)) )
@@ -1249,7 +1187,7 @@ def main(*argv):
             continue
         for s, t, v in ug.in_edges(n, keys=True):
             length, score, edges, type_ = u_edge_data[ (s, t, v) ]
-            if length > 30000:
+            if length > 50000 and len(edges) > 3:
                 continue
             in_degree = len( set( e[0] for e in ug.in_edges(s))  ) # ignore mutli-edges
             out_degree = len( set( e[1] for e in ug.out_edges(s)) )

--- a/src/py/mains/ovlp_to_graph.py
+++ b/src/py/mains/ovlp_to_graph.py
@@ -591,16 +591,6 @@ def find_bundle(ug, u_edge_data, start_node, depth_cutoff, width_cutoff, length_
 
     data = start_node, end_node, bundle_edges, length_to_node[end_node], score_to_node[end_node], depth
     
-    """
-    start_node_r, end_node_r = reverse_end(end_node), reverse_end(start_node)
-    
-    bundle_edge_r = set()
-    for v, w, k in list(bundle_edges):
-        vv, ww, kk = reverse_end(w), reverse_end(v), reverse_end(k)
-        bundle_edge_r.add( (vv, ww, kk) )
-
-    data_r = start_node_r, end_node_r, bundle_edge_r, length_to_node[end_node], score_to_node[end_node], depth
-    """
     data_r = None
 
     if DEBUG_LOG_LEVEL > 1:

--- a/src/py/mains/ovlp_to_graph.py
+++ b/src/py/mains/ovlp_to_graph.py
@@ -202,15 +202,19 @@ class StringGraph(object):
 
             out_edges = self.nodes[v].out_edges
             if len(out_edges) > 0:
-                out_edges.sort(key=lambda e: e.attr["score"])
-                e = out_edges[-1]
-                best_edges.add( (e.in_node.name, e.out_node.name) )
+                out_edges.sort(key=lambda e: -e.attr["score"])
+                for e in out_edges:
+                    if self.e_reduce[ (e.in_node.name, e.out_node.name) ] != True:
+                        best_edges.add( (e.in_node.name, e.out_node.name) )
+                        break
 
             in_edges = self.nodes[v].in_edges
             if len(in_edges) > 0:
-                in_edges.sort(key=lambda e: e.attr["score"])
-                e = in_edges[-1]
-                best_edges.add( (e.in_node.name, e.out_node.name) )
+                in_edges.sort(key=lambda e: -e.attr["score"])
+                for e in in_edges:
+                    if self.e_reduce[ (e.in_node.name, e.out_node.name) ] != True:
+                        best_edges.add( (e.in_node.name, e.out_node.name) )
+                        break
 
         if DEBUG_LOG_LEVEL > 1:
             print "X", len(best_edges)


### PR DESCRIPTION
After examining with whole genome alignments and the assembly graphs to understand why contigs break even though there are indeed sequence information linking different contigs, adding a couple heuristics to improve the sequence ovelaps to assembly graph to contig performance.  It is now possible generate a CHM1 assembly up to N50>25Mb and Max Contig Size > 100Mb with the recent P6 data. Whether such rules are general enough for other genomes is still under investigation.  