### PR TITLE
Fix SLURM support for FALCON

### DIFF
--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -38,7 +38,9 @@ def run_script(job_data, job_type = "SGE" ):
         job_name = job_data["job_name"]
         cwd = job_data["cwd"]
         sge_option = job_data["sge_option"]
-        fc_run_logger.info( "submitting %s for SGE, start job: %s " % (script_fn, job_name) )
+        with open(script_fn, 'r') as original: data = original.read()
+        with open(script_fn, 'w') as modified: modified.write("#!/bin/sh" + "\n" + data)
+        fc_run_logger.info( "submitting %s for SLURM, start job: %s " % (script_fn, job_name) )
         sge_cmd="sbatch -J {job_name} {sge_option} {script}".format(job_name=job_name, cwd=os.getcwd(),sge_option=sge_option, script=script_fn)
         cmd = sge_cmd
         rc = os.system(cmd)
@@ -87,6 +89,9 @@ def wait_for_file(filename, task, job_name = ""):
             if support.job_type == "SGE":
                 fc_run_logger.info( "deleting the job by `qdel` now..." )
                 os.system("qdel %s" % job_name) # Failure is ok.
+            if support.job_type == "SLURM":
+                fc_run_logger.info( "Deleting the job by 'scancel' now...")
+                os.system("scancel -n %s" % job_name)
             break
 
 def task_make_fofn_abs_raw(self):


### PR DESCRIPTION
rlleras wrote:
```
Had to come up with a simple way to fix the "Missing interpreter" error SLURM was giving with FALCON 0.3 that wouldn't break other schedulers. This should make FALCON stable for any future releases, and is compatible with Python 3.0+ as well, so no need to update code if/when Python version is updated.

Update run.py

Add SCANCEL support

Add support for SLURM jobs to automatically cancel failed jobs in event of FALCON failure.

fix indentation and loss of break

Update run.py
```
closes FALCON#181