### PR TITLE
refactoring run.py

### DIFF
--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -244,21 +244,26 @@ def task_run_consensus(self):
     wait_for_file(job_done, task=self, job_name=job_data['job_name'])
 
 
-def create_daligner_tasks(run_jobs_fn, wd, db_prefix, db_file, rdb_build_done, config, pread_aln = False):
-    job_id = 0
-    tasks = []
-    tasks_out = {}
-
+def get_nblock(db_file):
     nblock = 1
     new_db = True
-    if os.path.exists( fn(db_file) ):
-        with open( fn(db_file) ) as f:
+    if os.path.exists(db_file):
+        with open(db_file) as f:
             for l in f:
                 l = l.strip().split()
                 if l[0] == "blocks" and l[1] == "=":
                     nblock = int(l[2])
                     new_db = False
                     break
+    # Ignore new_db for now.
+    return nblock
+
+def create_daligner_tasks(run_jobs_fn, wd, db_prefix, db_file, rdb_build_done, config, pread_aln = False):
+    job_id = 0
+    tasks = []
+    tasks_out = {}
+
+    nblock = get_nblock(fn(db_file))
 
     for pid in xrange(1, nblock + 1):
         support.make_dirs("%s/m_%05d" % (wd, pid))

--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -265,9 +265,6 @@ def create_daligner_tasks(run_jobs_fn, wd, db_prefix, db_file, rdb_build_done, c
 
     nblock = get_nblock(fn(db_file))
 
-    for pid in xrange(1, nblock + 1):
-        support.make_dirs("%s/m_%05d" % (wd, pid))
-
     with open(run_jobs_fn) as f :
         for l in f :
             l = l.strip()

--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -370,7 +370,9 @@ def run_daligner(daligner_cmd, db_prefix, nblock, config, job_done, script_fn):
     script.append( "time "+ daligner_cmd )
 
     for p_id in xrange( 1, nblock+1 ):
-        script.append( """ for f in `find $PWD -wholename "*%s.%d.%s.*.*.las"`; do ln -sf $f ../m_%05d; done """  % (db_prefix, p_id, db_prefix, p_id) )
+        mdir = '../m_%05d' %p_id
+        script.append(""" for f in `find $PWD -wholename "*%s.%d.%s.*.*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(
+            db_prefix, p_id, db_prefix, mdir, mdir))
 
     script.append( "touch {job_done}".format(job_done = job_done) )
 


### PR DESCRIPTION
Minor.

Soon, `create_daligner_tasks()` will include LAsort lines with associated daligner lines, to avoid some network copies. Also, it will balance job-size better, I think.