### PR TITLE
Combine `LAsort` w/ `daligner` jobs

### DIFF
--- a/src/py/functional.py
+++ b/src/py/functional.py
@@ -33,8 +33,6 @@ def get_daligner_job_descriptions(run_jobs_stream, db_prefix):
     (In the example, X=2 A=1 B=2.)
 
     Comments and lines starting with LAmerge are ignored.
-
-    TODO: Also remove the direct output of daligner, which are not ordinarily removed by HPCdaligner calls.
     """
     re_block_dali = re.compile(r'%s\.(\d+)' %db_prefix)
     def blocks_dali(line):

--- a/src/py/functional.py
+++ b/src/py/functional.py
@@ -14,13 +14,14 @@ def _verify_pairs(pairs1, pairs2):
 def get_daligner_job_descriptions(run_jobs_stream, db_prefix):
     """Return a dict of job-desc-tuple -> HPCdaligner bash-job.
 
-    E.g.
+    E.g., each item will look like:
       (2, 1, 2, 3): 'daligner ...; LAsort ...; LAmerge ...; rm ...'
 
+    Rationale
+    ---------
     For i/o efficiency, we will combine daligner calls with LAsort lines, which include 0-level merge.
     Example:
       daligner -v -t16 -H12000 -e0.7 -s1000 raw_reads.2 raw_reads.1 raw_reads.2
-    X=2 A=1 B=2
     That would be combined with two LAsort lines:
       LAsort -v raw_reads.2.raw_reads.1.C0 ...
       LAsort -v raw_reads.2.raw_reads.2.C0 ...
@@ -29,10 +30,11 @@ def get_daligner_job_descriptions(run_jobs_stream, db_prefix):
     will then be
       L.1.X.A, L.1.X.B, and L.1.X.C
     where A, B, or C could be X.
+    (In the example, X=2 A=1 B=2.)
 
     Comments and lines starting with LAmerge are ignored.
 
-    TODO: Also remove the direct outpus of daligner, which are not ordinarily removed by HPCdaligner calls.
+    TODO: Also remove the direct output of daligner, which are not ordinarily removed by HPCdaligner calls.
     """
     re_block_dali = re.compile(r'%s\.(\d+)' %db_prefix)
     def blocks_dali(line):

--- a/src/py/functional.py
+++ b/src/py/functional.py
@@ -1,0 +1,74 @@
+"""Purely functional code.
+"""
+import collections
+import re
+
+def _verify_pairs(pairs1, pairs2):
+    if pairs1 != pairs2:
+        print('pair2dali:', pairs1)
+        print('pair2sort:', pairs2)
+        print('pair2dali:', len(pairs1))
+        print('pair2sort:', len(pairs2))
+        assert pairs1 == pairs2
+
+def get_daligner_job_descriptions(run_jobs_stream, db_prefix):
+    """Return a dict of job-desc-tuple -> HPCdaligner bash-job.
+
+    E.g.
+      (2, 1, 2, 3): 'daligner ...; LAsort ...; LAmerge ...; rm ...'
+
+    For i/o efficiency, we will combine daligner calls with LAsort lines, which include 0-level merge.
+    Example:
+      daligner -v -t16 -H12000 -e0.7 -s1000 raw_reads.2 raw_reads.1 raw_reads.2
+    X=2 A=1 B=2
+    That would be combined with two LAsort lines:
+      LAsort -v raw_reads.2.raw_reads.1.C0 ...
+      LAsort -v raw_reads.2.raw_reads.2.C0 ...
+    For each returned job, the result of
+      daligner X A B C; LAsort*
+    will then be
+      L.1.X.A, L.1.X.B, and L.1.X.C
+    where A, B, or C could be X.
+
+    Comments and lines starting with LAmerge are ignored.
+
+    TODO: Also remove the direct outpus of daligner, which are not ordinarily removed by HPCdaligner calls.
+    """
+    re_block_dali = re.compile(r'%s\.(\d+)' %db_prefix)
+    def blocks_dali(line):
+        return [mo.group(1) for mo in re_block_dali.finditer(line)]
+    # X == blocks[0]; A/B/C = blocks[...]
+
+    re_pair_sort = re.compile(r'%s\.(\d+)\.%s\.(\d+)' %(db_prefix, db_prefix))
+    def LAsort_pair(line):
+        return re_pair_sort.search(line).group(1, 2)
+
+    lines = [line.strip() for line in run_jobs_stream]
+    lines_dali = [l for l in lines if l.startswith('daligner')] # could be daligner_p
+    lines_sort = [l for l in lines if l.startswith('LAsort')]
+    pair2dali = {}
+    for line in lines_dali:
+        blocks = blocks_dali(line)
+        for block in blocks[1:]:
+            pair = (blocks[0], block)
+            pair2dali[pair] = line
+            if block != blocks[0]:
+                # Then we have a reverse comparison too.
+                # https://dazzlerblog.wordpress.com/2014/07/10/dalign-fast-and-sensitive-detection-of-all-pairwise-local-alignments/
+                rpair = (block, blocks[0])
+                pair2dali[rpair] = line
+    pair2sort = {}
+    for line in lines_sort:
+        pair = LAsort_pair(line)
+        pair2sort[pair] = line
+    _verify_pairs(sorted(pair2dali.keys()), sorted(pair2sort.keys()))
+    dali2pairs = collections.defaultdict(set)
+    for pair, dali in pair2dali.items():
+        dali2pairs[dali].add(pair)
+    result = {}
+    for dali, pairs in dali2pairs.items():
+        sorts = [pair2sort[pair] for pair in sorted(pairs, key=lambda k: (int(k[0]), int(k[1])))]
+        id = tuple(map(int, blocks_dali(dali)))
+        script = '\n'.join([dali] + sorts) + '\n'
+        result[id] = script
+    return result

--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -54,6 +54,10 @@ def run_script(job_data, job_type = "SGE" ):
         if rc:
             out = open(log_fn).read()
             fc_run_logger.warning('Contents of %r:\n%s' %(log_fn, out))
+    else:
+        msg = 'Unknown job_type=%s' %repr(job_type)
+        fc_run_logger.error(msg)
+        raise Exception(msg)
     if rc:
         msg = "Cmd %r (job %r) returned %d." % (cmd, job_name, rc)
         fc_run_logger.info(msg)

--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -370,8 +370,8 @@ def run_daligner(daligner_cmd, db_prefix, nblock, config, job_done, script_fn):
     script.append( "time "+ daligner_cmd )
 
     for p_id in xrange( 1, nblock+1 ):
-        #script.append('rm -f %s.*.%s.*.*.las' %(
-        #    db_prefix, db_prefix))
+        script.append('rm -f %s.*.%s.*.*.las' %(
+            db_prefix, db_prefix))
         mdir = '../m_%05d' %p_id
         script.append(""" for f in `find $PWD -wholename "*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(
             mdir, mdir))

--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -370,9 +370,15 @@ def run_daligner(daligner_cmd, db_prefix, nblock, config, job_done, script_fn):
     script.append( "time "+ daligner_cmd )
 
     for p_id in xrange( 1, nblock+1 ):
+        #script.append('rm -f %s.*.%s.*.*.las' %(
+        #    db_prefix, db_prefix))
         mdir = '../m_%05d' %p_id
-        script.append(""" for f in `find $PWD -wholename "*%s.%d.%s.*.*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(
-            db_prefix, p_id, db_prefix, mdir, mdir))
+        script.append(""" for f in `find $PWD -wholename "*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(
+            mdir, mdir))
+        #script.append(""" for f in `find $PWD -wholename "*%s.%d.%s.*.*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(db_prefix, p_id, db_prefix, mdir, mdir))
+        #script.append(""" for f in `find $PWD -wholename "*L1.*.*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(mdir, mdir))
+        # For raw_reads, the prefix is L1.*.las, but for preads, it is preads.*.las.
+        # I am not sure why yet. ~cdunn
 
     script.append( "touch {job_done}".format(job_done = job_done) )
 

--- a/test/HPCdaligner_synth0.sh
+++ b/test/HPCdaligner_synth0.sh
@@ -1,0 +1,11 @@
+# Daligner jobs (2)
+daligner -v -h1 -t16 -H1 -e0.7 -l1 -s1000 raw_reads.1 raw_reads.1
+daligner -v -h1 -t16 -H1 -e0.7 -l1 -s1000 raw_reads.2 raw_reads.1 raw_reads.2
+# Initial sort jobs (4)
+LAsort -v raw_reads.1.raw_reads.1.C0 raw_reads.1.raw_reads.1.N0 && LAmerge -v L1.1.1 raw_reads.1.raw_reads.1.C0.S raw_reads.1.raw_reads.1.N0.S && rm raw_reads.1.raw_reads.1.C0.S.las raw_reads.1.raw_reads.1.N0.S.las
+LAsort -v raw_reads.1.raw_reads.2.C0 raw_reads.1.raw_reads.2.N0 && LAmerge -v L1.1.2 raw_reads.1.raw_reads.2.C0.S raw_reads.1.raw_reads.2.N0.S && rm raw_reads.1.raw_reads.2.C0.S.las raw_reads.1.raw_reads.2.N0.S.las
+LAsort -v raw_reads.2.raw_reads.1.C0 raw_reads.2.raw_reads.1.N0 && LAmerge -v L1.2.1 raw_reads.2.raw_reads.1.C0.S raw_reads.2.raw_reads.1.N0.S && rm raw_reads.2.raw_reads.1.C0.S.las raw_reads.2.raw_reads.1.N0.S.las
+LAsort -v raw_reads.2.raw_reads.2.C0 raw_reads.2.raw_reads.2.N0 && LAmerge -v L1.2.2 raw_reads.2.raw_reads.2.C0.S raw_reads.2.raw_reads.2.N0.S && rm raw_reads.2.raw_reads.2.C0.S.las raw_reads.2.raw_reads.2.N0.S.las
+# Level 1 jobs (2)
+LAmerge -v raw_reads.1 L1.1.1 L1.1.2 && rm L1.1.1.las L1.1.2.las
+LAmerge -v raw_reads.2 L1.2.1 L1.2.2 && rm L1.2.1.las L1.2.2.las

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -1,0 +1,15 @@
+from nose.tools import eq_
+import falcon_kit.functional as f
+import StringIO
+import os
+
+thisdir = os.path.dirname(os.path.abspath(__file__))
+example_HPCdaligner = open(os.path.join(thisdir, 'HPCdaligner_synth0.sh'))
+
+def test_get_daligner_job_descriptions():
+    result = f.get_daligner_job_descriptions(
+            example_HPCdaligner, 'raw_reads')
+    assert result
+    eq_(result[(1, 1)], "daligner -v -h1 -t16 -H1 -e0.7 -l1 -s1000 raw_reads.1 raw_reads.1\nLAsort -v raw_reads.1.raw_reads.1.C0 raw_reads.1.raw_reads.1.N0 && LAmerge -v L1.1.1 raw_reads.1.raw_reads.1.C0.S raw_reads.1.raw_reads.1.N0.S && rm raw_reads.1.raw_reads.1.C0.S.las raw_reads.1.raw_reads.1.N0.S.las\n")
+    eq_(result[(2, 1, 2)], "daligner -v -h1 -t16 -H1 -e0.7 -l1 -s1000 raw_reads.2 raw_reads.1 raw_reads.2\nLAsort -v raw_reads.1.raw_reads.2.C0 raw_reads.1.raw_reads.2.N0 && LAmerge -v L1.1.2 raw_reads.1.raw_reads.2.C0.S raw_reads.1.raw_reads.2.N0.S && rm raw_reads.1.raw_reads.2.C0.S.las raw_reads.1.raw_reads.2.N0.S.las\nLAsort -v raw_reads.2.raw_reads.1.C0 raw_reads.2.raw_reads.1.N0 && LAmerge -v L1.2.1 raw_reads.2.raw_reads.1.C0.S raw_reads.2.raw_reads.1.N0.S && rm raw_reads.2.raw_reads.1.C0.S.las raw_reads.2.raw_reads.1.N0.S.las\nLAsort -v raw_reads.2.raw_reads.2.C0 raw_reads.2.raw_reads.2.N0 && LAmerge -v L1.2.2 raw_reads.2.raw_reads.2.C0.S raw_reads.2.raw_reads.2.N0.S && rm raw_reads.2.raw_reads.2.C0.S.las raw_reads.2.raw_reads.2.N0.S.las\n")
+    eq_(len(result), 2)


### PR DESCRIPTION
Combine `LAsort` w/ `daligner` jobs

This should reduce some network copying and might balance the jobs
better too.

Also, a nice functional test.

This works for me, both locally and in SGE. It definitely copies less data. I have not tested runtime impact, but it will affect NFS users more than us (on lustre).
