### PR TITLE
Rename get_dict() to get_dict_from_old_falcon_cfg()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ falcon_kit.egg-info/
 *.so
 *.dylib
 *.dll
+*.egg

--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -429,7 +429,7 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
     fc_run_logger = support.setup_logger(logger_config_fn)
 
     fc_run_logger.info( "fc_run started with configuration %s", input_config_fn ) 
-    config = support.get_config(support.parse_config(input_config_fn))
+    config = support.get_dict_from_old_falcon_cfg(support.parse_config(input_config_fn))
     rawread_dir = os.path.abspath("./0-rawreads")
     pread_dir = os.path.abspath("./1-preads_ovl")
     falcon_asm_dir  = os.path.abspath("./2-asm-falcon")

--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -73,12 +73,37 @@ def make_job_data(url, script_fn):
                 "script_fn": script_fn }
     return job_data
 
+def validate_config_dict(cd):
+    pass
+
+def get_config(config):
+    """Temporary version for pbsmrtpipe.
+    This will add missing (but curently required) options and use
+    get_dict_from_old_falcon_cfg() below.
+    The plan is to pass a simpler config from pbsmrtpipe,
+    but that will be in a different commit.
+    Side-effect: Update 'config'.
+    """
+    section = 'General'
+    def add(name, val):
+        if not config.has_option(section, name):
+            config.set(section, name, val)
+    add('input_fofn', 'NA')
+    add('target', 'assembly')
+    add('sge_option_da', 'NA')
+    add('sge_option_la', 'NA')
+    add('sge_option_pda', 'NA')
+    add('sge_option_pda', 'NA')
+    add('sge_option_fc', 'NA')
+    add('sge_option_cns', 'NA')
+    return get_dict_from_old_falcon_cfg(config)
+
 def parse_config(config_fn):
     config = ConfigParser.ConfigParser()
     config.read(config_fn)
     return config
 
-def get_config(config):
+def get_dict_from_old_falcon_cfg(config):
     global job_type  # TODO: Stop using global for wait_for_file().
     job_type = "SGE"
     if config.has_option('General', 'job_type'):


### PR DESCRIPTION
### Separate required options from pypeFLOW-related ones
#### Rename `get_dict()`.
This will let us alter FALCON-pbsmrtpipe without worrying about anything in
FALCON, but also without having to release a change to pbsmrtpipe
simultaneously (since that repo requires pull-requests).

#### A little more background
Because we sometimes drive FALCON from pbsmrtpipe, and because all options in pbsmrtpipe need specific documentation and inputting by the user, we need to stop requiring options which are not used in the pbsmrtpipe workflow.

I had planned to do this *after* simplifying how options are passed from pbsmrtpipe, but I am not going to win the argument over there.