### PR TITLE
Avoid too many ln/mkdir

### DIFF
--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -417,20 +417,6 @@ def run_daligner(daligner_cmd, db_prefix, nblock, config, job_done, script_fn):
         src_dir = os.path.abspath(os.path.dirname(cwd)) # by convention
         script.extend(use_tmpdir_for_files(basenames, src_dir, dst_dir))
     script.append( "time "+ daligner_cmd )
-    script.append( "set +vx" )
-    script.append( "date" )
-
-    for p_id in xrange( 1, nblock+1 ):
-        script.append('rm -f %s.*.%s.*.*.las' %(
-            db_prefix, db_prefix))
-        mdir = '../m_%05d' %p_id
-        script.append(""" for f in `find $PWD -wholename "*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(
-            mdir, mdir))
-        #script.append(""" for f in `find $PWD -wholename "*%s.%d.%s.*.*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(db_prefix, p_id, db_prefix, mdir, mdir))
-        #script.append(""" for f in `find $PWD -wholename "*L1.*.*.las"`; do mkdir -p %s; ln -sf $f %s; done """  %(mdir, mdir))
-        # For raw_reads, the prefix is L1.*.las, but for preads, it is preads.*.las.
-        # I am not sure why yet. ~cdunn
-
     script.append( "date" )
     script.append( "touch {job_done}".format(job_done = job_done) )
 


### PR DESCRIPTION
We no longer symlink anything after a daligner run. Instead,
we wait for all to finish; then we symlink the minimum set needed.

This resolves a problem discussed privately with @dgordon562.

Tested on simulated data with 50 blocks, 50 merge jobs, and 338 daligner jobs. (No typos.) It took a bit longer than usual (normally 1 minute for this 5kbp simulation), but it finished with a perfect assembly. I verified that it symlinked *exactly* 2500 (50*50) files into the m_* directories.

Currently, it does not rm old *.las files from the daligner runs, but it does rm intermediate *.las from the m_* merge directories.