### PR TITLE
Some refactoring

### DIFF
--- a/src/py/bash.py
+++ b/src/py/bash.py
@@ -1,0 +1,216 @@
+"""Most bash-scripting is generated here.
+"""
+from . import functional
+import os
+
+BASH='/bin/bash'
+
+
+def mkdir(d):
+    if not os.path.isdir(d):
+        os.makedirs(d)
+
+def write_script_and_wrapper(script, wrapper_fn, job_done, job_exit):
+    wdir = os.path.dirname(wrapper_fn)
+    #mkdir(wdir) # To avoid races, callers must do this.
+    root, ext = os.path.splitext(os.path.basename(wrapper_fn))
+    sub_script_bfn = root + '.sub' + ext
+
+    # Try to avoid 'text file busy' in open():
+    #os.listdir(wdir)
+    #os.system('touch {}'.format(os.path.join(wdir, sub_script_bfn)))
+    os.system('rm -f {}'.format(os.path.join(wdir, sub_script_bfn)))
+
+    with open(os.path.join(wdir, sub_script_bfn), 'w') as ofs:
+        # We use shebang + chmod so we can see the sub-script in 'top'.
+        # In order to avoid '/bin/bash: bad interpreter: Text file busy',
+        # we 'touch' the sub-script after chmod.
+        #   http://superuser.com/questions/934300/bin-bash-bad-interpreter-text-file-busy-even-though-the-file-editor-closed
+        ofs.write('#!{}\n'.format(BASH))
+        ofs.write('set -vex\n')
+        ofs.write(script)
+    wrapper = """
+set -vex
+trap 'touch {job_exit}' EXIT
+cd {wdir}
+hostname
+chmod +x {sub_script_bfn}
+touch {sub_script_bfn}
+time ./{sub_script_bfn}
+touch {job_done}
+""".format(**locals())
+    with open(wrapper_fn, 'w') as ofs:
+        ofs.write(wrapper)
+    return job_done, job_exit
+
+def script_build_rdb(config, input_fofn_fn, run_jobs_fn):
+    """
+    raw_reads.db will be output into CWD, and might already exist.
+    run_jobs_bfn will be output into CWD.
+    """
+    last_block = 1
+    new_db = True
+    if os.path.exists("raw_reads.db"):
+        with open("raw_reads.db") as f:
+            for l in f:
+                l = l.strip().split()
+                if l[0] == "blocks" and l[1] == "=":
+                    last_block = int(l[2])
+                    new_db = False
+                    break
+
+    DBsplit = 'DBsplit {pa_DBsplit_option} raw_reads'.format(**config) if new_db else ''
+    openending = config["openending"]
+    if openending == True:
+        count = """$(cat raw_reads.db | awk '$1 == "blocks" {print $3-1}')"""
+    else:
+        count = """$(cat raw_reads.db | awk '$1 == "blocks" {print $3}')"""
+    params = dict(config)
+    params.update(locals())
+    script = """\
+fasta2DB -v raw_reads -f{input_fofn_fn}
+{DBsplit}
+LB={count}
+HPCdaligner {pa_HPCdaligner_option} -H{length_cutoff} raw_reads {last_block}-$LB >| {run_jobs_fn}
+""".format(**params)
+    return script
+
+def script_build_pdb(config, input_fofn_fn, run_jobs_fn):
+    params = dict(config)
+    params.update(locals())
+    script = """\
+fasta2DB -v preads -f{input_fofn_fn}
+DBsplit {ovlp_DBsplit_option} preads
+HPCdaligner {ovlp_HPCdaligner_option} -H{length_cutoff_pr} preads >| {run_jobs_fn}
+""".format(**params)
+    return script
+
+def script_run_DB2Falcon(config):
+    """Run in pread_dir.
+    """
+    params = dict(config)
+    params.update(locals())
+    script = """\
+# Given preads.db,
+# write preads4falcon.fasta, in 1-preads_ovl:
+time DB2Falcon -U preads
+""".format(**params)
+    return script
+
+def scripts_daligner(run_jobs_fn, db_prefix, rdb_build_done, pread_aln=False):
+    """Yield job_uid, bash
+    """
+    scripts = {}
+    xform_script = functional.get_script_xformer(pread_aln)
+    db_dir = os.path.dirname(run_jobs_fn)
+    job_descs = functional.get_daligner_job_descriptions(open(run_jobs_fn), db_prefix)
+    for i, (desc, bash) in enumerate(job_descs.iteritems()):
+        job_uid = '%04x' %i
+        daligner_cmd = xform_script(bash)
+        bash = """
+db_dir={db_dir}
+ln -sf ${{db_dir}}/.{db_prefix}.bps .
+ln -sf ${{db_dir}}/.{db_prefix}.idx .
+ln -sf ${{db_dir}}/{db_prefix}.db .
+{daligner_cmd}
+#rm -f *.C?.las
+#rm -f *.N?.las
+""".format(db_dir=db_dir, db_prefix=db_prefix, daligner_cmd=daligner_cmd)
+        yield job_uid, bash
+
+def scripts_merge(config, db_prefix, run_jobs_fn):
+    """Yield p_id, bash
+    """
+    mjob_data = {}
+    with open(run_jobs_fn) as f:
+        for l in f:
+            l = l.strip().split()
+            if l[0] not in ( "LAsort", "LAmerge", "mv" ):
+                continue
+            if l[0] == "LAsort":
+                # We now run this part w/ daligner, but we still need
+                # a small script for some book-keeping.
+                p_id = int( l[2].split(".")[1] )
+                mjob_data.setdefault( p_id, [] )
+                #mjob_data[p_id].append(  " ".join(l) ) # Already done w/ daligner!
+            if l[0] == "LAmerge":
+                l2 = l[2].split(".")
+                if l2[1][0] == "L":
+                    p_id = int(  l[2].split(".")[2] )
+                    mjob_data.setdefault( p_id, [] )
+                    mjob_data[p_id].append(  " ".join(l) )
+                else:
+                    p_id = int( l[2].split(".")[1] )
+                    mjob_data.setdefault( p_id, [] )
+                    mjob_data[p_id].append(  " ".join(l) )
+            if l[0] == "mv":
+                l2 = l[1].split(".")
+                if l2[1][0] == "L":
+                    p_id = int(  l[1].split(".")[2] )
+                    mjob_data.setdefault( p_id, [] )
+                    mjob_data[p_id].append(  " ".join(l) )
+                else:
+                    p_id = int( l[1].split(".")[1] )
+                    mjob_data.setdefault( p_id, [] )
+                    mjob_data[p_id].append(  " ".join(l) )
+    for p_id in mjob_data:
+        bash_lines = mjob_data[p_id]
+
+        #support.make_dirs("%s/m_%05d" % (wd, p_id))
+        #support.make_dirs("%s/preads" % (wd))
+        #support.make_dirs("%s/las_files" % (wd))
+        #merge_script_file = os.path.abspath("%s/m_%05d/m_%05d.sh" % (wd, p_id, p_id))
+
+        script = []
+        for line in bash_lines:
+            script.append(line.replace('&&', ';'))
+        script.append("mkdir -p ../las_files")
+        script.append("ln -sf ../m_%05d/%s.%d.las ../las_files" % (p_id, db_prefix, p_id))
+        script.append("ln -sf ./m_%05d/%s.%d.las .. " % (p_id, db_prefix, p_id))
+        yield p_id, '\n'.join(script + [''])
+
+def script_run_consensus(config, db_fn, las_fn, out_file_bfn):
+    """config: falcon_sense_option, length_cutoff
+    """
+    params = dict(config)
+    params.update(locals())
+    if config["falcon_sense_skip_contained"]:
+        pipe = """LA4Falcon -H{length_cutoff} -fso {db_fn} {las_fn} | """
+    else:
+        pipe = """LA4Falcon -H{length_cutoff}  -fo {db_fn} {las_fn} | """
+    pipe += """fc_consensus {falcon_sense_option} >| {out_file_bfn}"""
+
+    script = """
+set -o pipefail
+%s
+""" %pipe
+    return script.format(**params)
+
+def script_run_falcon_asm(config, pread_dir, db_file):
+    params = dict(config)
+    params.update(locals())
+    script = """\
+# Generate las.fofn:
+find {pread_dir}/las_files -name "*.las" >| las.fofn
+
+# Given, las.fofn,
+# write preads.ovl:
+time fc_ovlp_filter --db {db_file} --fofn las.fofn {overlap_filtering_setting} --min_len {length_cutoff_pr} >| preads.ovl
+
+ln -sf {pread_dir}/preads4falcon.fasta .
+# TODO: Figure out which steps need preads4falcon.fasta.
+
+# Given preads.ovl,
+# write sg_edges_list, c_path, utg_data, ctg_paths.
+time fc_ovlp_to_graph preads.ovl --min_len {length_cutoff_pr} >| fc_ovlp_to_graph.log
+
+# Given sg_edges_list, utg_data, ctg_paths,
+# Write p_ctg.fa and a_ctg_all.fa,
+# plus a_ctg_base.fa, p_ctg_tiling_path, a_ctg_tiling_path, a_ctg_base_tiling_path:
+time fc_graph_to_contig
+
+# Given a_ctg_all.fa, write a_ctg.fa:
+time fc_dedup_a_tigs
+"""
+    return script.format(**params)
+

--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -1,5 +1,6 @@
 from .. import run_support as support
-from ..functional import get_daligner_job_descriptions, get_script_xformer
+from .. import bash
+from ..run_support import get_nblock #temp
 from pypeflow.data import PypeLocalFile, makePypeLocalFile, fn
 from pypeflow.task import PypeTask, PypeThreadTaskBase, PypeTaskBase
 from pypeflow.controller import PypeThreadWorkflow
@@ -144,7 +145,6 @@ def task_build_rdb(self):
     script_fn = os.path.join( work_dir, "prepare_rdb.sh" )
     args = {
         'input_fofn_fn': input_fofn_fn,
-        'work_dir': work_dir,
         'config': config,
         'job_done': job_done,
         'script_fn': script_fn,
@@ -167,7 +167,6 @@ def task_build_pdb(self):  #essential the same as build_rdb() but the subtle dif
     script_fn = os.path.join( work_dir, "prepare_pdb.sh" )
     args = {
         'input_fofn_fn': input_fofn_fn,
-        'work_dir': work_dir,
         'config': config,
         'job_done': job_done,
         'script_fn': script_fn,
@@ -180,9 +179,27 @@ def task_build_pdb(self):  #essential the same as build_rdb() but the subtle dif
     run_script(job_data, job_type = config["job_type"])
     wait_for_file(job_done, task=self, job_name=job_data['job_name'])
 
+def task_run_db2falcon(self):
+    wd = self.parameters["wd"]
+    #self.p_merge_done
+    job_done = fn(self.db2falcon_done)
+    config = self.parameters["config"]
+    script_dir = os.path.join(wd)
+    script_fn = os.path.join(script_dir ,"run_db2falcon.sh")
+    args = {
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+    }
+    support.run_db2falcon(**args)
+
+    job_data = support.make_job_data(self.URL, script_fn)
+    run_script(job_data, job_type=config["job_type"])
+    wait_for_file(job_done, task=self, job_name=job_data['job_name'])
+
 def task_run_falcon_asm(self):
     wd = self.parameters["wd"]
-    #p_merge_done = self.p_merge_done
+    #self.db2falcon_done
     db_file = fn(self.db_file)
     job_done = fn(self.falcon_asm_done)
     config = self.parameters["config"]
@@ -205,16 +222,17 @@ def task_run_falcon_asm(self):
 
 def task_run_daligner(self):
     job_done = fn(self.job_done)
-    daligner_cmd = self.parameters["daligner_cmd"]
+    daligner_script = self.parameters["daligner_script"]
     job_uid = self.parameters["job_uid"]
     cwd = self.parameters["cwd"]
+    mkdir(cwd)
     db_prefix = self.parameters["db_prefix"]
     config = self.parameters["config"]
     sge_option_da = config["sge_option_da"]
-    script_dir = os.path.join( cwd )
-    script_fn =  os.path.join( script_dir , "rj_%s.sh" % (job_uid))
+    script_dir = os.path.join(cwd)
+    script_fn =  os.path.join(script_dir , "rj_%s.sh" % (job_uid))
     args = {
-        'daligner_cmd': daligner_cmd,
+        'daligner_script': daligner_script,
         'db_prefix': db_prefix,
         'config': config,
         'job_done': job_done,
@@ -228,7 +246,7 @@ def task_run_daligner(self):
     wait_for_file(job_done, task=self, job_name=job_data['job_name'])
 
 def task_run_las_merge(self):
-    p_script_fn = self.parameters["merge_script"]
+    script = self.parameters["merge_script"]
     job_id = self.parameters["job_id"]
     cwd = self.parameters["cwd"]
     job_done = fn(self.job_done)
@@ -238,7 +256,7 @@ def task_run_las_merge(self):
     script_dir = os.path.join( cwd )
     script_fn =  os.path.join( script_dir , "rp_%05d.sh" % (job_id))
     args = {
-        'p_script_fn': p_script_fn,
+        'script': script,
         'config': config,
         'job_done': job_done,
         'script_fn': script_fn,
@@ -291,159 +309,85 @@ def task_daligner_gather(self):
         mdir = os.path.join(main_dir, 'm_%05d' %block) # By convention. pbsmrtpipe works differently.
         mkdir(mdir)
         # TODO: Remove existing symlinks?
+    job_rundirs = [os.path.dirname(fn(dal_done)) for dal_done in out_dict.values()]
 
     # Symlink all daligner *.las.
-    # Could be L1.* or preads.*
-    re_las = re.compile(r'\.(\d*)(\.\d*)?\.las$')
-    for dal_done in out_dict.values():
-        job_rundir = os.path.dirname(fn(dal_done))
-        for las_fn in os.listdir(job_rundir):
-            mo = re_las.search(las_fn)
-            if not mo:
-                continue
-            block = int(mo.group(1)) # We will merge in the m_* dir of the left block.
+    for block, las_path in support.daligner_gather_las(job_rundirs):
+            fc_run_logger.warning('block: %s, las_path: %s' %(block, las_path))
             mdir = os.path.join(main_dir, 'm_%05d' %block) # By convention. pbsmrtpipe works differently.
-            las_path = os.path.join('..', os.path.basename(job_rundir), las_fn)
+            las_path = os.path.relpath(las_path, mdir)
             cmd = 'ln -sf {} {}'.format(las_path, mdir)
             system(cmd)
     system("touch %s" %da_done)
 
-def get_nblock(db_file):
-    nblock = 1
-    new_db = True
-    if os.path.exists(db_file):
-        with open(db_file) as f:
-            for l in f:
-                l = l.strip().split()
-                if l[0] == "blocks" and l[1] == "=":
-                    nblock = int(l[2])
-                    new_db = False
-                    break
-    # Ignore new_db for now.
-    return nblock
-
 def create_daligner_tasks(run_jobs_fn, wd, db_prefix, rdb_build_done, config, pread_aln=False):
     tasks = []
     tasks_out = {}
-
-    xform_script = get_script_xformer(pread_aln)
-
-    line_count = 0
-    job_descs = get_daligner_job_descriptions(open(run_jobs_fn), db_prefix)
-    for desc, bash in job_descs.iteritems():
-        job_uid = '%04x' %line_count
-        line_count += 1
-
-        support.make_dirs(os.path.join( wd, "./job_%s" % job_uid))
-        call = "cd %s/job_%s;ln -sf ../.%s.bps .; ln -sf ../.%s.idx .; ln -sf ../%s.db ." % (wd, job_uid, db_prefix, db_prefix, db_prefix)
-        rc = system(call)
-        if rc:
-            raise Exception("Failure in system call: %r -> %d" %(call, rc))
-        job_done = makePypeLocalFile(os.path.abspath( "%s/job_%s/job_%s_done" % (wd, job_uid, job_uid)  ))
-        bash = xform_script(bash)
-        parameters =  {"daligner_cmd": bash,
-                        "cwd": os.path.join(wd, "job_%s" % job_uid),
-                        "job_uid": job_uid,
-                        "config": config,
-                        "db_prefix": db_prefix}
-        make_daligner_task = PypeTask( inputs = {"rdb_build_done": rdb_build_done},
-                                        outputs = {"job_done": job_done},
-                                        parameters = parameters,
-                                        TaskType = PypeThreadTaskBase,
-                                        URL = "task://localhost/d_%s_%s" % (job_uid, db_prefix) )
-        daligner_task = make_daligner_task( task_run_daligner )
-        tasks.append( daligner_task )
+    for job_uid, script in bash.scripts_daligner(run_jobs_fn, db_prefix, rdb_build_done, pread_aln):
+        run_dir = "job_%s" %job_uid
+        cwd = os.path.join(wd, run_dir)
+        job_done_fn = os.path.abspath(os.path.join(cwd, "job_%s_done" %job_uid))
+        job_done = makePypeLocalFile(job_done_fn)
+        parameters =  {"daligner_script": script,
+                       "cwd": cwd,
+                       "job_uid": job_uid,
+                       "config": config,
+                       "db_prefix": db_prefix}
+        make_daligner_task = PypeTask(inputs = {"rdb_build_done": rdb_build_done},
+                                      outputs = {"job_done": job_done},
+                                      parameters = parameters,
+                                      TaskType = PypeThreadTaskBase,
+                                      URL = "task://localhost/d_%s_%s" %(job_uid, db_prefix))
+        daligner_task = make_daligner_task(task_run_daligner)
+        tasks.append(daligner_task)
         tasks_out[ "ajob_%s" % job_uid ] = job_done
     return tasks, tasks_out
 
 def create_merge_tasks(run_jobs_fn, wd, db_prefix, input_dep, config):
     merge_tasks = []
-    consensus_tasks = []
     merge_out = {}
-    consensus_out ={}
-    mjob_data = {}
+    p_ids_merge_job_done = [] # for consensus
 
-    with open(run_jobs_fn) as f :
-        for l in f:
-            l = l.strip().split()
-            if l[0] not in ( "LAsort", "LAmerge", "mv" ):
-                continue
-            if l[0] == "LAsort":
-                # We now run this part w/ daligner, but we still need
-                # a small script for some book-keeping.
-                p_id = int( l[2].split(".")[1] )
-                mjob_data.setdefault( p_id, [] )
-                #mjob_data[p_id].append(  " ".join(l) ) # Already done w/ daligner!
-            if l[0] == "LAmerge":
-                l2 = l[2].split(".")
-                if l2[1][0] == "L":
-                    p_id = int(  l[2].split(".")[2] )
-                    mjob_data.setdefault( p_id, [] )
-                    mjob_data[p_id].append(  " ".join(l) )
-                else:
-                    p_id = int( l[2].split(".")[1] )
-                    mjob_data.setdefault( p_id, [] )
-                    mjob_data[p_id].append(  " ".join(l) )
-            if l[0] == "mv":
-                l2 = l[1].split(".")
-                if l2[1][0] == "L":
-                    p_id = int(  l[1].split(".")[2] )
-                    mjob_data.setdefault( p_id, [] )
-                    mjob_data[p_id].append(  " ".join(l) )
-                else:
-                    p_id = int( l[1].split(".")[1] )
-                    mjob_data.setdefault( p_id, [] )
-                    mjob_data[p_id].append(  " ".join(l) )
-
-    for p_id in mjob_data:
-        s_data = mjob_data[p_id]
-
-        support.make_dirs("%s/m_%05d" % (wd, p_id))
-        support.make_dirs("%s/preads" % (wd) )
-        support.make_dirs("%s/las_files" % (wd) )
-
-        merge_script_file = os.path.abspath( "%s/m_%05d/m_%05d.sh" % (wd, p_id, p_id) )
-        with open(merge_script_file, "w") as merge_script:
-            #print >> merge_script, """for f in `find .. -wholename "*job*/%s.%d.%s.*.*.las"`; do ln -sf $f .; done""" % (db_prefix, p_id, db_prefix)
-            for l in s_data:
-                print >> merge_script, l
-            print >> merge_script, "ln -sf ../m_%05d/%s.%d.las ../las_files" % (p_id, db_prefix, p_id) 
-            print >> merge_script, "ln -sf ./m_%05d/%s.%d.las .. " % (p_id, db_prefix, p_id) 
-            
-        job_done = makePypeLocalFile(os.path.abspath( "%s/m_%05d/m_%05d_done" % (wd, p_id, p_id)  ))
-        parameters =  {"merge_script": merge_script_file, 
+    merge_scripts = bash.scripts_merge(config, db_prefix, run_jobs_fn)
+    for p_id, merge_script in merge_scripts:
+        job_done = makePypeLocalFile(os.path.abspath("%s/m_%05d/m_%05d_done" % (wd, p_id, p_id)))
+        parameters =  {"merge_script": merge_script,
                        "cwd": os.path.join(wd, "m_%05d" % p_id),
                        "job_id": p_id,
                        "config": config}
-
-        make_merge_task = PypeTask( inputs = {"input_dep": input_dep},
-                                       outputs = {"job_done": job_done},
-                                       parameters = parameters,
-                                       TaskType = PypeThreadTaskBase,
-                                       URL = "task://localhost/m_%05d_%s" % (p_id, db_prefix) )
-        merge_task = make_merge_task ( task_run_las_merge)
-
+        make_merge_task = PypeTask(inputs = {"input_dep": input_dep},
+                                   outputs = {"job_done": job_done},
+                                   parameters = parameters,
+                                   TaskType = PypeThreadTaskBase,
+                                   URL = "task://localhost/m_%05d_%s" % (p_id, db_prefix))
+        merge_task = make_merge_task(task_run_las_merge)
         merge_out["mjob_%d" % p_id] = job_done
         merge_tasks.append(merge_task)
+        p_ids_merge_job_done.append((p_id, job_done))
+    return merge_tasks, merge_out, p_ids_merge_job_done
 
-
-        out_file = makePypeLocalFile(os.path.abspath( "%s/preads/out.%05d.fasta" % (wd, p_id)  ))
-        out_done = makePypeLocalFile(os.path.abspath( "%s/preads/c_%05d_done" % (wd, p_id)  ))
-        parameters =  {"cwd": os.path.join(wd, "preads" ),
+def create_consensus_tasks(wd, db_prefix, config, p_ids_merge_job_done):
+    consensus_tasks = []
+    consensus_out ={}
+    # Unlike the merge tasks, consensus occurs in a single directory.
+    rdir = os.path.join(wd, 'preads')
+    mkdir(rdir)
+    for p_id, job_done in p_ids_merge_job_done:
+        out_file = makePypeLocalFile(os.path.abspath("%s/preads/out.%05d.fasta" % (wd, p_id)))
+        out_done = makePypeLocalFile(os.path.abspath("%s/preads/c_%05d_done" % (wd, p_id)))
+        parameters =  {"cwd": rdir,
                        "job_id": p_id, 
                        "prefix": db_prefix,
                        "config": config}
-        make_c_task = PypeTask( inputs = {"job_done": job_done},
-                                outputs = {"out_file": out_file, "out_done": out_done },
-                                parameters = parameters,
-                                TaskType = PypeThreadTaskBase,
-                                URL = "task://localhost/ct_%05d" % p_id )
-        
-        c_task = make_c_task( task_run_consensus)
+        make_c_task = PypeTask(inputs = {"job_done": job_done},
+                               outputs = {"out_file": out_file, "out_done": out_done},
+                               parameters = parameters,
+                               TaskType = PypeThreadTaskBase,
+                               URL = "task://localhost/ct_%05d" % p_id)
+        c_task = make_c_task(task_run_consensus)
         consensus_tasks.append(c_task)
         consensus_out["cjob_%d" % p_id] = out_done 
-
-    return merge_tasks, merge_out, consensus_tasks, consensus_out
+    return consensus_tasks, consensus_out
 
 
 
@@ -451,7 +395,7 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
     global fc_run_logger
     fc_run_logger = support.setup_logger(logger_config_fn)
 
-    fc_run_logger.info( "fc_run started with configuration %s", input_config_fn ) 
+    fc_run_logger.info("fc_run started with configuration %s", input_config_fn)
     config = support.get_dict_from_old_falcon_cfg(support.parse_config(input_config_fn))
     rawread_dir = os.path.abspath("./0-rawreads")
     pread_dir = os.path.abspath("./1-preads_ovl")
@@ -485,8 +429,10 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
         parameters = {"work_dir": rawread_dir,
                       "config": config}
 
+        raw_reads_db = makePypeLocalFile(os.path.join( rawread_dir, "%s.db" % "raw_reads" ))
         make_build_rdb_task = PypeTask(inputs = {"input_fofn": rawread_fofn_plf},
                                       outputs = {"rdb_build_done": rdb_build_done,
+                                                 "raw_reads.db": raw_reads_db,
                                                  "run_jobs": run_jobs}, 
                                       parameters = parameters,
                                       TaskType = PypeThreadTaskBase)
@@ -495,8 +441,7 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
         wf.addTasks([build_rdb_task])
         wf.refreshTargets([rdb_build_done]) 
 
-        db_file = makePypeLocalFile(os.path.join( rawread_dir, "%s.db" % "raw_reads" ))
-        raw_reads_nblock = get_nblock(fn(db_file))
+        raw_reads_nblock = support.get_nblock(fn(raw_reads_db))
         #### run daligner
         daligner_tasks, daligner_out = create_daligner_tasks(fn(run_jobs), rawread_dir, "raw_reads", rdb_build_done, config) 
 
@@ -517,13 +462,12 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
         wf.addTask(check_r_da_task)
         wf.refreshTargets(updateFreq = wait_time) # larger number better for more jobs, need to call to run jobs here or the # of concurrency is changed
         
-        concurrent_jobs = config["cns_concurrent_jobs"]
-        PypeThreadWorkflow.setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
-        merge_tasks, merge_out, consensus_tasks, consensus_out = create_merge_tasks(fn(run_jobs), rawread_dir, "raw_reads", r_da_done, config)
+        merge_tasks, merge_out, p_ids_merge_job_done = create_merge_tasks(fn(run_jobs), rawread_dir, "raw_reads", r_da_done, config)
         wf.addTasks( merge_tasks )
         if config["target"] == "overlapping":
             wf.refreshTargets(updateFreq = wait_time) # larger number better for more jobs, need to call to run jobs here or the # of concurrency is changed
             sys.exit(0)
+        consensus_tasks, consensus_out = create_consensus_tasks(rawread_dir, "raw_reads", config, p_ids_merge_job_done)
         wf.addTasks( consensus_tasks )
 
         r_cns_done = makePypeLocalFile( os.path.join( rawread_dir, "cns_done") )
@@ -540,8 +484,10 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
                 for fa_fn in fn_list:
                     print >>f, fa_fn
             system("touch %s" % fn(self.cns_done))
-
         wf.addTask(check_r_cns_task)
+
+        concurrent_jobs = config["cns_concurrent_jobs"]
+        PypeThreadWorkflow.setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
         wf.refreshTargets(updateFreq = wait_time) # larger number better for more jobs
 
     if config["target"] == "pre-assembly":
@@ -563,9 +509,11 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
                   "config": config}
 
     run_jobs = makePypeLocalFile(os.path.join(pread_dir, 'run_jobs.sh'))
-    make_build_pdb_task  = PypeTask(inputs = { "pread_fofn": pread_fofn },
-                                    outputs = { "pdb_build_done": pdb_build_done,
-                                                "run_jobs": run_jobs},
+    preads_db = makePypeLocalFile(os.path.join(pread_dir, 'preads.db')) # Also .preads.*, of course.
+    make_build_pdb_task  = PypeTask(inputs = {"pread_fofn": pread_fofn },
+                                    outputs = {"pdb_build_done": pdb_build_done,
+                                               "preads_db": preads_db,
+                                               "run_jobs": run_jobs},
                                     parameters = parameters,
                                     TaskType = PypeThreadTaskBase,
                                     URL = "task://localhost/build_pdb")
@@ -575,19 +523,14 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
     wf.refreshTargets([pdb_build_done]) 
 
 
-
-    db_file = makePypeLocalFile(os.path.join( pread_dir, "%s.db" % "preads" ))
-    preads_nblock = get_nblock(fn(db_file))
+    preads_nblock = support.get_nblock(fn(preads_db))
     #### run daligner
-    concurrent_jobs = config["ovlp_concurrent_jobs"]
-    PypeThreadWorkflow.setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
     config["sge_option_da"] = config["sge_option_pda"]
     config["sge_option_la"] = config["sge_option_pla"]
     daligner_tasks, daligner_out = create_daligner_tasks(fn(run_jobs), pread_dir, "preads", pdb_build_done, config, pread_aln=True)
     wf.addTasks(daligner_tasks)
-    #wf.refreshTargets(updateFreq = 30) # larger number better for more jobs
 
-    p_da_done = makePypeLocalFile( os.path.join( pread_dir, "da_done") )
+    p_da_done = makePypeLocalFile(os.path.join( pread_dir, "da_done"))
     parameters =  {
             "nblock": preads_nblock,
     }
@@ -600,27 +543,40 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
     check_p_da_task = make_daligner_gather(task_daligner_gather)
     wf.addTask(check_p_da_task)
 
-    merge_tasks, merge_out, consensus_tasks, consensus_out = create_merge_tasks(fn(run_jobs), pread_dir, "preads", p_da_done, config)
+    merge_tasks, merge_out, _ = create_merge_tasks(fn(run_jobs), pread_dir, "preads", p_da_done, config)
     wf.addTasks( merge_tasks )
-    #wf.refreshTargets(updateFreq = 30) #all
 
-    p_merge_done = makePypeLocalFile( os.path.join( pread_dir, "p_merge_done") )
+    p_merge_done = makePypeLocalFile(os.path.join( pread_dir, "p_merge_done"))
 
     @PypeTask( inputs = merge_out, 
-               outputs =  {"p_merge_done":p_merge_done},
+               outputs =  {"p_merge_done": p_merge_done},
                TaskType = PypeThreadTaskBase,
                URL = "task://localhost/pmerge_check" )
     def check_p_merge_check_task(self):
         system("touch %s" % fn(self.p_merge_done))
-    
     wf.addTask(check_p_merge_check_task)
+
+    concurrent_jobs = config["ovlp_concurrent_jobs"]
+    PypeThreadWorkflow.setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
+
     wf.refreshTargets(updateFreq = wait_time) #all
 
     
+    db2falcon_done = makePypeLocalFile( os.path.join(pread_dir, "db2falcon_done"))
+    make_run_db2falcon = PypeTask(
+               inputs = {"p_merge_done": p_merge_done,},
+               outputs =  {"db2falcon_done": db2falcon_done},
+               parameters = {"wd": pread_dir,
+                             "config": config,
+                            },
+               TaskType = PypeThreadTaskBase,
+               URL = "task://localhost/db2falcon" )
+    wf.addTask(make_run_db2falcon(task_run_db2falcon))
+
     falcon_asm_done = makePypeLocalFile( os.path.join( falcon_asm_dir, "falcon_asm_done") )
     make_run_falcon_asm = PypeTask(
-               inputs = {"p_merge_done": p_merge_done, "db_file":db_file},
-               outputs =  {"falcon_asm_done":falcon_asm_done},
+               inputs = {"db2falcon_done": db2falcon_done, "db_file": preads_db},
+               outputs =  {"falcon_asm_done": falcon_asm_done},
                parameters = {"wd": falcon_asm_dir,
                              "config": config,
                              "pread_dir": pread_dir},


### PR DESCRIPTION
* Generate scripts independent of workflow, runnable in any
  directory.
  * Use templates for scripts where possible, for transparency.
  * Generate done/exit wrappers in a generic way, decoupled from sub-scripts.
  * Use shebang lines for sub-scripts, so they will show up in **top**.
* Separate Consensus task from Merge.
* Separate DB2Falcon task.
* Identify more inputs/outputs, for better restarts.
* Drop 'tmpdir' (until we are more specific about input/outputs).

This will dramatically simplify pbsmrtpipe integration, as well as pypeflow improvements.