### PR TITLE
Stop all jobs on failure

### DIFF
--- a/src/py/mains/run.py
+++ b/src/py/mains/run.py
@@ -418,7 +418,7 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
     for d in (rawread_dir, pread_dir, falcon_asm_dir, script_dir, sge_log_dir):
         support.make_dirs(d)
 
-    exitOnFailure=config['stop_all_jobs_on_failure']
+    exitOnFailure=config['stop_all_jobs_on_failure'] # only matter for parallel jobs
     concurrent_jobs = config["pa_concurrent_jobs"]
     PypeThreadWorkflow.setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
     wf = PypeThreadWorkflow()
@@ -476,8 +476,9 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
         
         merge_tasks, merge_out, p_ids_merge_job_done = create_merge_tasks(fn(run_jobs), rawread_dir, "raw_reads", r_da_done, config)
         wf.addTasks( merge_tasks )
+        wf.refreshTargets(exitOnFailure=exitOnFailure)
+
         if config["target"] == "overlapping":
-            wf.refreshTargets(exitOnFailure=exitOnFailure)
             sys.exit(0)
         consensus_tasks, consensus_out = create_consensus_tasks(rawread_dir, "raw_reads", config, p_ids_merge_job_done)
         wf.addTasks( consensus_tasks )
@@ -554,6 +555,7 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
                 URL = "task://localhost/pda_check" )
     check_p_da_task = make_daligner_gather(task_daligner_gather)
     wf.addTask(check_p_da_task)
+    wf.refreshTargets(exitOnFailure=exitOnFailure)
 
     merge_tasks, merge_out, _ = create_merge_tasks(fn(run_jobs), pread_dir, "preads", p_da_done, config)
     wf.addTasks( merge_tasks )

--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -190,6 +190,10 @@ def get_dict_from_old_falcon_cfg(config):
         logger.info(""" No target specified, assuming "assembly" as target """)
         target = "assembly"
 
+    if config.has_option(section, 'stop_all_jobs_on_failure'):
+        stop_all_jobs_on_failure = config.getboolean(section, 'stop_all_jobs_on_failure')
+    else:
+        stop_all_jobs_on_failure = False
     if config.has_option(section, 'use_tmpdir'):
         use_tmpdir = config.getboolean(section, 'use_tmpdir')
     else:
@@ -219,6 +223,7 @@ def get_dict_from_old_falcon_cfg(config):
                    "ovlp_DBsplit_option": ovlp_DBsplit_option,
                    "falcon_sense_option": falcon_sense_option,
                    "falcon_sense_skip_contained": falcon_sense_skip_contained,
+                   "stop_all_jobs_on_failure": stop_all_jobs_on_failure,
                    "use_tmpdir": use_tmpdir,
                    }
     provided = dict(config.items(section))

--- a/src/py/run_support.py
+++ b/src/py/run_support.py
@@ -193,6 +193,8 @@ def get_dict_from_old_falcon_cfg(config):
     if config.has_option(section, 'stop_all_jobs_on_failure'):
         stop_all_jobs_on_failure = config.getboolean(section, 'stop_all_jobs_on_failure')
     else:
+        # Good default. Rarely needed, since we already stop early if *all* tasks fail
+        # in a given refresh.
         stop_all_jobs_on_failure = False
     if config.has_option(section, 'use_tmpdir'):
         use_tmpdir = config.getboolean(section, 'use_tmpdir')


### PR DESCRIPTION
As a *separate* change in pypeFLOW, we can ignore ignoreOnFailure if there are not successful jobs yet when the first one fails. In that case, we can just fail early.

But this change to FALCON is independent of that one. So we can merge this first. We can update FALCON-integrate with *both* changes. I'll post the pypeFLOW PR soon...