### PR TITLE
Implemented coverage filters for consensus.py

### DIFF
--- a/src/py/mains/consensus.py
+++ b/src/py/mains/consensus.py
@@ -25,14 +25,15 @@ def get_longest_reads(seqs, max_n_read, max_cov_aln, sort=True):
         seed_len = len(seqs[0])
         read_cov = 0
         for seq in seqs[1:]:
-            # avoid an annoying +1 in seqs[:longest_n_reads], 
-            # count first break later
-            longest_n_reads += 1
-            read_cov += len(seq)
             if read_cov//seed_len > max_cov_aln: 
                 break
+            longest_n_reads += 1
+            read_cov += len(seq)
+
         longest_n_reads = min(longest_n_reads, max_n_read)
-    return( seqs[:longest_n_reads] )
+
+    return( seqs[:longest_n_reads+1] )
+
 
 def get_alignment(seq1, seq0, edge_tolerance = 1000):
 

--- a/src/py/mains/consensus.py
+++ b/src/py/mains/consensus.py
@@ -21,7 +21,7 @@ def get_longest_reads(seqs, max_n_read, max_cov_aln, sort=True):
 
     longest_n_reads = max_n_read
     if max_cov_aln > 0:
-        longest_n_reads = 0
+        longest_n_reads = 1
         seed_len = len(seqs[0])
         read_cov = 0
         for seq in seqs[1:]:
@@ -32,7 +32,7 @@ def get_longest_reads(seqs, max_n_read, max_cov_aln, sort=True):
 
         longest_n_reads = min(longest_n_reads, max_n_read)
 
-    return( seqs[:longest_n_reads+1] )
+    return( seqs[:longest_n_reads] )
 
 
 def get_alignment(seq1, seq0, edge_tolerance = 1000):


### PR DESCRIPTION
New `--max_cov_aln` option as an alternative to `--max_n_reads`: cap the number of reads by average coverage of longest alignments rather than a fixed max number of reads; `--min_cov_aln` option moved to more appropriately named `--min_n_read` and a new `--min_cov_aln` implemented to filter reads by min average coverage. See issue #284 