### PR TITLE
Calc length_cutoff

### DIFF
--- a/falcon_kit/FastaReader.py
+++ b/falcon_kit/FastaReader.py
@@ -245,7 +245,7 @@ class FastaReader(ReaderBase):
         ref000002|EGFR_Exon_3 203 4bf218da37175a91869033024ac8f9e9
         ref000003|EGFR_Exon_4 215 245bc7a046aad0788c22b071ed210f4d
         ref000004|EGFR_Exon_5 157 c368b8191164a9d6ab76fd328e2803ca
-        >>> r.close()
+        > r.close()
     """
     DELIMITER = ">"
 

--- a/falcon_kit/functional.py
+++ b/falcon_kit/functional.py
@@ -105,6 +105,10 @@ def calc_cutoff_from_reverse_sorted_readlength_counts(rl_counts, target):
     return cutoff
 
 def num2int(num):
+    """
+    >>> num2int('1,000,000')
+    1000000
+    """
     return int(num.replace(',', ''))
 
 def get_reverse_sorted_readlength_counts_from_DBstats(DBstats_output):

--- a/falcon_kit/functional.py
+++ b/falcon_kit/functional.py
@@ -87,3 +87,49 @@ def get_script_xformer(pread_aln):
         return xform_script_for_preads
     else:
         return xform_script_for_raw_reads
+
+def calc_cutoff_from_reverse_sorted_readlength_counts(rl_counts, target):
+    """Return first read_len which gives at least 'target' bases.
+    """
+    total = sum(pair[0]*pair[1] for pair in rl_counts)
+    subtotal = 0
+    assert target <= total, (target, total)
+    cutoff = 0
+    for (rl, count) in rl_counts:
+        subtotal += rl*count
+        if subtotal >= target:
+            cutoff = rl
+            break
+    else:
+        raise Exception('Impossible target: target={target}, subtotal={subtotal}, total={total}'.format(locals()))
+    return cutoff
+
+def num2int(num):
+    return int(num.replace(',', ''))
+
+def get_reverse_sorted_readlength_counts_from_DBstats(DBstats_output):
+    """Return pairs of (readlength, count).
+        Bin:      Count  % Reads  % Bases     Average
+    169,514:          1      0.0      0.0      169514
+    ...
+    ->
+    [(169514, 1), ...]
+    """
+    rl_counts = list()
+    lines = DBstats_output.splitlines()
+    re_stat = re.compile(r'^\s*(?P<bin>\S+):\s+(?P<count>\S+)\s+\S+\s+\S+\s+\S+\s*$')
+    for line in lines:
+        match = re_stat.search(line)
+        if not match:
+            continue
+        rl = num2int(match.group('bin'))
+        count = num2int(match.group('count'))
+        rl_counts.append((rl, count))
+    return rl_counts
+
+def calc_cutoff(target, DBstats_output):
+    """Calculate the length_cutoff needed for at least 'target' bases.
+    DBstats_output: ASCII output of 'DBstats -b1 DB',
+    """
+    rl_counts = get_reverse_sorted_readlength_counts_from_DBstats(DBstats_output)
+    return calc_cutoff_from_reverse_sorted_readlength_counts(rl_counts, target)

--- a/falcon_kit/mains/calc_cutoff.py
+++ b/falcon_kit/mains/calc_cutoff.py
@@ -1,0 +1,36 @@
+from .. import functional as f
+import argparse
+import sys
+
+def main(argv=sys.argv):
+    import argparse
+
+    description = """
+Given the result of 'DBstats -u -b1' on stdin,
+print the lowest read-length required for sufficient coverage of the genome
+(i.e. 'length_cutoff').
+"""
+    epilog = """
+This is useful when length_cutoff is not provided but the genome-size
+can be estimated. The purpose is to *reduce* the amount of data seen by
+DALIGNER, since otherwise it will miss many alignments when it
+encounters resource limits.
+"""
+    parser = argparse.ArgumentParser(description=description, epilog=epilog,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--coverage', type=float, default=20,
+            help='Desired coverage ratio (i.e. over-sampling)')
+    parser.add_argument('genome_size', type=int,
+            help='Estimated number of bases in genome. (haploid?)')
+    parser.add_argument('capture', default='-',
+            help='File with captured output of DBstats. (Otherwise, stdin.)')
+    args = parser.parse_args(argv[1:])
+
+    target = int(args.genome_size * args.coverage)
+    capture = open(args.capture) if args.capture!='-' else sys.stdin
+    stats = capture.read()
+    cutoff = f.calc_cutoff(target, stats)
+    sys.stdout.write(str(cutoff))
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/falcon_kit/run_support.py
+++ b/falcon_kit/run_support.py
@@ -176,10 +176,23 @@ def get_dict_from_old_falcon_cfg(config):
         else:
             falcon_sense_skip_contained = False
 
-    length_cutoff = config.getint(section, 'length_cutoff')
-    input_fofn_fn = config.get(section, 'input_fofn')
+    genome_size = 0
+    if config.has_option(section, 'genome_size'):
+        genome_size = config.getint(section, 'genome_size')
+
+    seed_coverage = 20
+    if config.has_option(section, 'seed_coverage'):
+        seed_coverage = config.getint(section, 'seed_coverage')
+
+    length_cutoff = -1
+    if config.has_option(section, 'length_cutoff'):
+        length_cutoff = config.getint(section, 'length_cutoff')
+    if length_cutoff < 0:
+        if genome_size < 1:
+            raise Exception('Must specify either length_cutoff>0 or genome_size>0')
 
     length_cutoff_pr = config.getint(section, 'length_cutoff_pr')
+    input_fofn_fn = config.get(section, 'input_fofn')
 
     # This one depends on length_cutoff_pr for its default.
     fc_ovlp_to_graph_option = ''
@@ -226,6 +239,8 @@ def get_dict_from_old_falcon_cfg(config):
                    "ovlp_concurrent_jobs" : ovlp_concurrent_jobs,
                    "cns_concurrent_jobs" : cns_concurrent_jobs,
                    "overlap_filtering_setting": overlap_filtering_setting,
+                   "genome_size" : genome_size,
+                   "seed_coverage" : seed_coverage,
                    "length_cutoff" : length_cutoff,
                    "length_cutoff_pr" : length_cutoff_pr,
                    "sge_option_da": config.get(section, 'sge_option_da'),

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(name='falcon_kit',
           'fc_ovlp_filter=falcon_kit.mains.ovlp_filter:main',
           'fc_ovlp_stats=falcon_kit.mains.ovlp_stats:main',
           'fc_ovlp_to_graph=falcon_kit.mains.ovlp_to_graph:main',
+          'fc_calc_cutoff=falcon_kit.mains.calc_cutoff:main',
           'fc_run=falcon_kit.mains.run:main',
           'fc_run1=falcon_kit.mains.run1:main', # someday, this can replace fc_run
           ],

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -1,6 +1,7 @@
-from nose.tools import eq_
+from nose.tools import assert_equal, assert_raises, eq_
 import falcon_kit.functional as f
 import StringIO
+import collections
 import os
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
@@ -29,3 +30,62 @@ def test_xform_script_for_preads():
 
     eq_(f.get_script_xformer(True), f.xform_script_for_preads)
     eq_(f.get_script_xformer(False), f.xform_script_for_raw_reads)
+
+def test_calc_cutoff_from_reverse_sorted_readlength_counts():
+    read_lens = [1,2,2,3]
+    rs_rl_counts = [(3, 1), (2, 2), (1, 1)]
+    assert collections.Counter(read_lens) == dict(rs_rl_counts)
+    def check(target, expected):
+        got = f.calc_cutoff_from_reverse_sorted_readlength_counts(rs_rl_counts, target)
+        assert_equal(expected, got)
+    for n, expected in (
+            (8, 1),
+            (7, 2),
+            (4, 2),
+            (3, 3),
+            (1, 3),
+            (0, 3),
+        ):
+        yield check, n, expected
+    assert_raises(Exception, check, 9, None)
+
+capture = """
+Statistics for all reads of length 500 bases or more
+
+        240,548 reads        out of         309,410  ( 77.7%)
+  1,117,649,525 base pairs   out of   1,320,493,403  ( 84.6%)
+
+          4,646 average read length
+          6,418 standard deviation
+
+  Base composition: 0.264(A) 0.247(C) 0.279(G) 0.211(T)
+
+  Distribution of Read Lengths (Bin size = 1)
+
+        Bin:      Count  % Reads  % Bases     Average
+    169,514:          1      0.0      0.0      169514
+    169,513:          0      0.0      0.0      169514
+
+"""
+def test_get_reverse_sorted_readlength_counts_from_DBstats():
+    got = f.get_reverse_sorted_readlength_counts_from_DBstats(capture)
+    expected = [(169514, 1), (169513, 0)]
+    assert_equal(expected, got)
+
+def test_num2int():
+    assert_equal(5, f.num2int('5'))
+    assert_equal(1000, f.num2int('1,000'))
+    assert_equal(1000000, f.num2int('1,000,000'))
+
+partial_capture = """
+        Bin:      Count  % Reads  % Bases     Average
+          4:          2      0.0      0.0      xxx
+          3:          0      0.0      0.0      xxx
+          2:          3      0.0      0.0      xxx
+          1:          8      0.0      0.0      xxx
+"""
+def test_calc_cutoff():
+    target = 14
+    expected = 2
+    got = f.calc_cutoff(target, partial_capture)
+    eq_(expected, got)

--- a/travis.sh
+++ b/travis.sh
@@ -15,4 +15,6 @@ python -c 'import falcon_kit; print falcon_kit.falcon'
 # When doctests are passing, add this:
 pip install nose
 nosetests -v test/
-#nosetests -v --with-doctest fc-env/lib/python2.7/site-packages/falcon_kit
+nosetests -v --with-doctest falcon_kit/functional.py
+# We cannot run that on *all* modules because some include dependencies.
+# Just pypeFLOW for now, but I would rather not test dependencies.


### PR DESCRIPTION
Based on `DBstats -b1`.

A bit messy for now, and calculated in twice 2 different steps,
since we do not want to add another pbsmrtpipe task. But **DBstats**
should be super-fast even on a large genome.