### PR TITLE
dust and pa_DBdust_option

### DIFF
--- a/falcon_kit/bash.py
+++ b/falcon_kit/bash.py
@@ -116,14 +116,20 @@ def script_build_rdb(config, input_fofn_fn, run_jobs_fn):
             params['genome_size'], params['seed_coverage'], 'raw_reads')
     else:
         bash_cutoff = '{}'.format(length_cutoff)
+    DBdust = 'DBdust {} raw_reads'.format(params.get('pa_DBdust_options', ''))
+    mdust = '-mdust'
+    if not params.get('dust'):
+        DBdust = "#" + DBdust
+        mdust = ''
     params.update(locals())
     script = """\
 fasta2DB -pfakemoviename -v raw_reads -f{input_fofn_fn}
 {DBsplit}
+{DBdust}
 LB={count}
 rm -f {run_jobs_fn}
 CUTOFF={bash_cutoff}
-HPCdaligner {pa_HPCdaligner_option} -H$CUTOFF raw_reads {last_block}-$LB >| {run_jobs_fn}
+HPCdaligner {pa_HPCdaligner_option} {mdust} -H$CUTOFF raw_reads {last_block}-$LB >| {run_jobs_fn}
 """.format(**params)
     return script
 
@@ -169,6 +175,8 @@ db_dir={db_dir}
 ln -sf ${{db_dir}}/.{db_prefix}.bps .
 ln -sf ${{db_dir}}/.{db_prefix}.idx .
 ln -sf ${{db_dir}}/{db_prefix}.db .
+ln -sf ${{db_dir}}/.{db_prefix}.dust.anno .
+ln -sf ${{db_dir}}/.{db_prefix}.dust.data .
 {daligner_cmd}
 #rm -f *.C?.las
 #rm -f *.N?.las

--- a/falcon_kit/run_support.py
+++ b/falcon_kit/run_support.py
@@ -157,6 +157,14 @@ def get_dict_from_old_falcon_cfg(config):
     if config.has_option(section, 'pa_DBsplit_option'):
         pa_DBsplit_option = config.get(section, 'pa_DBsplit_option')
 
+    dust = False
+    if config.has_option(section, 'dust'):
+        dust = config.get(section, 'dust')
+
+    pa_DBdust_option = ""
+    if config.has_option(section, 'pa_DBdust_option'):
+        pa_DBdust_option = config.get(section, 'pa_DBdust_option')
+
     ovlp_DBsplit_option = """ -x500 -s200"""
     if config.has_option(section, 'ovlp_DBsplit_option'):
         ovlp_DBsplit_option = config.get(section, 'ovlp_DBsplit_option')
@@ -252,6 +260,8 @@ def get_dict_from_old_falcon_cfg(config):
                    "pa_HPCdaligner_option": pa_HPCdaligner_option,
                    "ovlp_HPCdaligner_option": ovlp_HPCdaligner_option,
                    "pa_DBsplit_option": pa_DBsplit_option,
+                   "dust": dust,
+                   "pa_DBdust_option": pa_DBdust_option,
                    "ovlp_DBsplit_option": ovlp_DBsplit_option,
                    "fc_ovlp_to_graph_option": fc_ovlp_to_graph_option,
                    "falcon_sense_option": falcon_sense_option,


### PR DESCRIPTION
**DBdust** shows very little improvement for Lambda, but it might help in extreme cases. Eventually, we can turn this on by default, but it could cause us to lose physical homopolymers. For now it needs more experimenting testing.

To activate:

    dust = true

The defaults for `pa_DBdust_option` seem fine. I've tried some others, with no improvement.