### PR TITLE
Minor bug

### DIFF
--- a/falcon_kit/mains/ctg_link_analysis.py
+++ b/falcon_kit/mains/ctg_link_analysis.py
@@ -74,7 +74,8 @@ def main(argv=None):
                 s2,t2,v2 = u2
                 len_1 = ctg_data[ ctg1 ][ 3 ]
                 len_2 = ctg_data[ ctg2 ][ 3 ]
-                print ctg1, ctg2, len_1, len_2, len(utg1), len(utg2), len(links), "~".join( (s1,v1,t1) ),  "~".join( (s2,v2,t2) ), len(c)
+                print '{} {} {:7d}\t{:7d}\t{}\t{}\t{}\t{} {} {}'.format(
+                        ctg1, ctg2, len_1, len_2, len(utg1), len(utg2), len(links), "~".join( (s1,v1,t1) ),  "~".join( (s2,v2,t2) ), len(c))
 
 
 

--- a/falcon_kit/mains/graph_to_contig.py
+++ b/falcon_kit/mains/graph_to_contig.py
@@ -104,7 +104,9 @@ def main(argv=None):
             if s < t:
                 e_seq = seqs[ rid ][ s:t ]
             else:
-                e_seq = "".join([ RCMAP[c] for c in seqs[ rid ][ s:t:-1 ] ])
+                # t and s were swapped for 'c' alignments in ovlp_to_graph.generate_string_graph():702
+                # They were translated from reverse-dir to forward-dir coordinate system in LA4Falcon.
+                e_seq = "".join([ RCMAP[c] for c in seqs[ rid ][ t:s ][::-1] ])
             edge_data[ (v, w) ] = ( rid, s, t, aln_score, idt, e_seq )
 
     utg_data = {}

--- a/falcon_kit/mains/ovlp_to_graph.py
+++ b/falcon_kit/mains/ovlp_to_graph.py
@@ -825,7 +825,9 @@ def generate_string_graph(args):
         elif sg.e_reduce[(v, w)] == True:
             type_ = "TR"
 
-        print >>out_f, v, w, rid, sp, tp, score, identity, type_
+        line = '%s %s %s %5d %5d %5d %5.2f %s' %(
+                v, w, rid, sp, tp, score, identity, type_)
+        print >>out_f, line
 
 
 


### PR DESCRIPTION
Oddly, I was describing precisely this oddity of Python to Gene Myers
earlier today. (We've been discussing the ambiguities in various interval representations.)

This will not fix the graph problem that I am investigating. I haven't looked into how it might impact contigs, but I can say that for my tiny (5knt) error-free test-case, the result is simply to shift the (circular) draft assembly by 1 base.

I've also slightly altered some Falcon outputs, to make them more human readable. Since parses split on whitespace, this will make no difference.