### PR TITLE
SGE: fix Eqw error when 'shell_start_mode' option is set to 'unix_behavior'

### DIFF
--- a/falcon_kit/mains/run.py
+++ b/falcon_kit/mains/run.py
@@ -38,6 +38,8 @@ def _qsub_script(job_data, specific):
         job_name = job_data["job_name"]
         cwd = job_data["cwd"]
         sge_option = job_data["sge_option"]
+        with open(script_fn, 'r') as original: data = original.read()
+        with open(script_fn, 'w') as modified: modified.write("#!/bin/bash" + "\n" + data)
         sge_cmd="qsub -N {job_name} {sge_option} -o {cwd}/sge_log {specific}\
                  -S /bin/bash {script}".format(job_name=job_name,
                                                cwd=os.getcwd(),


### PR DESCRIPTION
Hi,
I run Faclon on a SGE cluster, and I have problems with jobs failing in Eqw state.
The problem comes from the fact that the cluster is configured with 'unix_behavior' for the 'shell_start_mode'. With this configuration, all scripts submitted to the cluster must have a shebang definition to run correctly.
Here's a little patch to always add a shebang to generated scripts. It is almost the same as for the slurm scheduler.