### PR TITLE
Do not rm intermediate .las files

### DIFF
--- a/falcon_kit/functional.py
+++ b/falcon_kit/functional.py
@@ -109,6 +109,9 @@ def get_mjob_data(run_jobs_stream):
     """
     f = run_jobs_stream
 
+    # Strip either '&& rm ...' or '; rm ...'
+    re_strip_rm = re.compile(r'^(.*) ((\&\&)|;) .*$')
+
     # Copied from scripts_merge()
     mjob_data = {}
     for l in f:
@@ -125,6 +128,8 @@ def get_mjob_data(run_jobs_stream):
         elif first_word in ["LAmerge"]:
             p_id = first_block_las(l)
             mjob_data.setdefault( p_id, [] )
+            l = re_strip_rm.sub(r'\1', l)
+            # We will have to rm the left-over *.las later.
             mjob_data[p_id].append(l)
     return mjob_data
 

--- a/test/HPCdaligner_synth0.sh
+++ b/test/HPCdaligner_synth0.sh
@@ -8,4 +8,4 @@ LAsort -v raw_reads.2.raw_reads.1.C0 raw_reads.2.raw_reads.1.N0 && LAmerge -v L1
 LAsort -v raw_reads.2.raw_reads.2.C0 raw_reads.2.raw_reads.2.N0 && LAmerge -v L1.2.2 raw_reads.2.raw_reads.2.C0.S raw_reads.2.raw_reads.2.N0.S && rm raw_reads.2.raw_reads.2.C0.S.las raw_reads.2.raw_reads.2.N0.S.las
 # Level 1 jobs (2)
 LAmerge -v raw_reads.1 L1.1.1 L1.1.2 && rm L1.1.1.las L1.1.2.las
-LAmerge -v raw_reads.2 L1.2.1 L1.2.2 && rm L1.2.1.las L1.2.2.las
+LAmerge -v raw_reads.2 L1.2.1 L1.2.2 ; rm L1.2.1.las L1.2.2.las

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -5,15 +5,24 @@ import collections
 import os
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
-example_HPCdaligner = open(os.path.join(thisdir, 'HPCdaligner_synth0.sh'))
+example_HPCdaligner_fn = os.path.join(thisdir, 'HPCdaligner_synth0.sh')
 
 def test_get_daligner_job_descriptions():
+    example_HPCdaligner = open(example_HPCdaligner_fn)
     result = f.get_daligner_job_descriptions(
             example_HPCdaligner, 'raw_reads')
     assert result
     eq_(result[('.1', '.1')], "daligner -v -h1 -t16 -H1 -e0.7 -l1 -s1000 raw_reads.1 raw_reads.1\nLAsort -v raw_reads.1.raw_reads.1.C0 raw_reads.1.raw_reads.1.N0 && LAmerge -v L1.1.1 raw_reads.1.raw_reads.1.C0.S raw_reads.1.raw_reads.1.N0.S && rm raw_reads.1.raw_reads.1.C0.S.las raw_reads.1.raw_reads.1.N0.S.las\n")
     eq_(result[('.2', '.1', '.2')], "daligner -v -h1 -t16 -H1 -e0.7 -l1 -s1000 raw_reads.2 raw_reads.1 raw_reads.2\nLAsort -v raw_reads.1.raw_reads.2.C0 raw_reads.1.raw_reads.2.N0 && LAmerge -v L1.1.2 raw_reads.1.raw_reads.2.C0.S raw_reads.1.raw_reads.2.N0.S && rm raw_reads.1.raw_reads.2.C0.S.las raw_reads.1.raw_reads.2.N0.S.las\nLAsort -v raw_reads.2.raw_reads.1.C0 raw_reads.2.raw_reads.1.N0 && LAmerge -v L1.2.1 raw_reads.2.raw_reads.1.C0.S raw_reads.2.raw_reads.1.N0.S && rm raw_reads.2.raw_reads.1.C0.S.las raw_reads.2.raw_reads.1.N0.S.las\nLAsort -v raw_reads.2.raw_reads.2.C0 raw_reads.2.raw_reads.2.N0 && LAmerge -v L1.2.2 raw_reads.2.raw_reads.2.C0.S raw_reads.2.raw_reads.2.N0.S && rm raw_reads.2.raw_reads.2.C0.S.las raw_reads.2.raw_reads.2.N0.S.las\n")
     eq_(len(result), 2)
+
+def test_get_mjob_data():
+    example_HPCdaligner = open(example_HPCdaligner_fn)
+    result = f.get_mjob_data(
+            example_HPCdaligner)
+    assert result
+    eq_(result[1], ['LAmerge -v raw_reads.1 L1.1.1 L1.1.2'])
+    eq_(result[2], ['LAmerge -v raw_reads.2 L1.2.1 L1.2.2'])
 
 def test_first_block_las():
     line = 'LAsort -v -a -q foo.1.foo.1.C0'


### PR DESCRIPTION
If the merge job fails, then we might need to re-run the whole step.
(Note: If we run in a tmp-dir always, then we make *every* step atomic.
 Then, we will not need this change at all.)

Handle both '&&' style and ';' style. And add a test for each.

This should help with #349, but eventually it will be better to merge in `/tmp` and consider the whole task either done or not done.