### PR TITLE
Implement `use_tmpdir`

### DIFF
--- a/falcon_kit/functional.py
+++ b/falcon_kit/functional.py
@@ -109,8 +109,8 @@ def get_mjob_data(run_jobs_stream):
     """
     f = run_jobs_stream
 
-    # Strip either '&& rm ...' or '; rm ...'
-    re_strip_rm = re.compile(r'^(.*) ((\&\&)|;) .*$')
+    ## Strip either '&& rm ...' or '; rm ...' ?
+    #re_strip_rm = re.compile(r'^(.*) ((\&\&)|;) .*$')
 
     # Copied from scripts_merge()
     mjob_data = {}
@@ -128,8 +128,7 @@ def get_mjob_data(run_jobs_stream):
         elif first_word in ["LAmerge"]:
             p_id = first_block_las(l)
             mjob_data.setdefault( p_id, [] )
-            l = re_strip_rm.sub(r'\1', l)
-            # We will have to rm the left-over *.las later.
+            #l = re_strip_rm.sub(r'\1', l) # rm is very safe if we run in /tmp
             mjob_data[p_id].append(l)
     return mjob_data
 

--- a/falcon_kit/mains/run.py
+++ b/falcon_kit/mains/run.py
@@ -254,7 +254,7 @@ def task_run_falcon_asm(self):
     script_dir = os.path.join( wd )
     script_fn =  os.path.join( script_dir ,"run_falcon_asm.sh" )
     # Generate las.fofn in run-dir.
-    system('cd {}; find {}/las_files -name "*.las" >| las.fofn'.format(wd, pread_dir))
+    system('cd {}; find {}/m_*/ -name "*.las" >| las.fofn'.format(wd, pread_dir))
     las_fofn_fn = 'las.fofn'
     args = {
         'las_fofn_fn': las_fofn_fn,
@@ -319,8 +319,8 @@ def task_run_consensus(self):
     script_dir = os.path.join( cwd )
     job_done = os.path.join( cwd, "c_%05d_done" % job_id )
     script_fn =  os.path.join( script_dir , "c_%05d.sh" % (job_id))
-    db_fn = '../{prefix}'.format(**locals())
-    las_fn = '../las_files/{prefix}.{job_id}.las'.format(**locals())
+    db_fn = os.path.abspath('{cwd}/../{prefix}'.format(**locals()))
+    las_fn = os.path.abspath('{cwd}/../m_{job_id:05d}/{prefix}.{job_id}.las'.format(**locals()))
     args = {
         'db_fn': db_fn,
         'las_fn': las_fn,

--- a/falcon_kit/mains/run1.py
+++ b/falcon_kit/mains/run1.py
@@ -117,7 +117,7 @@ def task_run_falcon_asm(self):
     script_dir = os.path.join( wd )
     script_fn =  os.path.join( script_dir ,"run_falcon_asm.sh" )
     # Generate las.fofn in run-dir.
-    system('cd {}; find {}/las_files -name "*.las" >| las.fofn'.format(wd, pread_dir))
+    system('cd {}; find {}/m_*/ -name "*.las" >| las.fofn'.format(wd, pread_dir))
     las_fofn_fn = 'las.fofn'
     args = {
         'las_fofn_fn': las_fofn_fn,
@@ -185,8 +185,8 @@ def task_run_consensus(self):
     script_dir = os.path.join( cwd )
     job_done = os.path.join( cwd, "c_%05d_done" % job_id )
     script_fn =  os.path.join( script_dir , "c_%05d.sh" % (job_id))
-    db_fn = '../{prefix}'.format(**locals())
-    las_fn = '../las_files/{prefix}.{job_id}.las'.format(**locals())
+    db_fn = os.path.abspath('{cwd}/../{prefix}'.format(**locals()))
+    las_fn = os.path.abspath('{cwd}/../m_{job_id:05d}/{prefix}.{job_id}.las'.format(**locals()))
     args = {
         'db_fn': db_fn,
         'las_fn': las_fn,

--- a/falcon_kit/run_support.py
+++ b/falcon_kit/run_support.py
@@ -430,32 +430,29 @@ def daligner_gather_las(job_rundirs):
             yield block, os.path.join(job_rundir, las_fn)
 
 def build_rdb(input_fofn_fn, config, job_done, script_fn, run_jobs_fn):
+    run_jobs_fn = os.path.basename(run_jobs_fn)
     script = bash.script_build_rdb(config, input_fofn_fn, run_jobs_fn)
-    bash.write_script_and_wrapper(script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(script, script_fn, job_done)
 
 def build_pdb(input_fofn_fn, config, job_done, script_fn, run_jobs_fn):
+    run_jobs_fn = os.path.basename(run_jobs_fn)
     script = bash.script_build_pdb(config, input_fofn_fn, run_jobs_fn)
-    bash.write_script_and_wrapper(script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(script, script_fn, job_done)
 
 def run_db2falcon(config, job_done, script_fn):
     script = bash.script_run_DB2Falcon(config)
-    bash.write_script_and_wrapper(script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(script, script_fn, job_done)
 
 def run_falcon_asm(config, las_fofn_fn, preads4falcon_fasta_fn, db_file_fn, job_done, script_fn):
     script = bash.script_run_falcon_asm(config, las_fofn_fn, preads4falcon_fasta_fn, db_file_fn)
-    bash.write_script_and_wrapper(script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(script, script_fn, job_done)
 
 def run_daligner(daligner_script, db_prefix, config, job_done, script_fn):
-    if config['use_tmpdir']:
-        # Really, we want to copy the symlinked db to tmpdir.
-        # The output is fine in NFS.
-        # Tricky. TODO.
-        logger.warning('use_tmpdir currently ignored')
-    bash.write_script_and_wrapper(daligner_script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(daligner_script, script_fn, job_done)
 
 def run_las_merge(script, job_done, config, script_fn):
-    bash.write_script_and_wrapper(script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(script, script_fn, job_done)
 
 def run_consensus(db_fn, las_fn, out_file_fn, config, job_done, script_fn):
     script = bash.script_run_consensus(config, db_fn, las_fn, os.path.basename(out_file_fn))
-    bash.write_script_and_wrapper(script, script_fn, job_done)
+    bash.get_write_script_and_wrapper(config)(script, script_fn, job_done)

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -21,8 +21,8 @@ def test_get_mjob_data():
     result = f.get_mjob_data(
             example_HPCdaligner)
     assert result
-    eq_(result[1], ['LAmerge -v raw_reads.1 L1.1.1 L1.1.2'])
-    eq_(result[2], ['LAmerge -v raw_reads.2 L1.2.1 L1.2.2'])
+    eq_(result[1], ['LAmerge -v raw_reads.1 L1.1.1 L1.1.2 && rm L1.1.1.las L1.1.2.las'])
+    eq_(result[2], ['LAmerge -v raw_reads.2 L1.2.1 L1.2.2 ; rm L1.2.1.las L1.2.2.las'])
 
 def test_first_block_las():
     line = 'LAsort -v -a -q foo.1.foo.1.C0'


### PR DESCRIPTION
This is now a better implementation than before. We symlink all NFS files from the work-dir into a run-dir under `/tmp`. Then, only after completion, we *move* the non-symlinks from the tmp run-dir back to the NFS work-dir. This should completely solve #350.

However, we still do not copy (or rsync) the DB  or other inputs into `/tmp`. That would take a bit of work. According to @dgordon562 in #345, the daligner jobs do not need this, but **LA4Falcon** could benefit from a DB in `/tmp` because it uses non-sequential access of the DB. That is TODO.

For another example of weird problems when runnning in NFS that are solved when running in `/tmp`, see this comment:
* https://github.com/PacificBiosciences/blasr/issues/232#issuecomment-216943603

Someday, we can add some **LAcheck** calls for good measure. For now, we strip those from **HPC.daligner**.