### PR TITLE
New command-line argparser for ovlpfilter

### DIFF
--- a/falcon_kit/bash.py
+++ b/falcon_kit/bash.py
@@ -299,10 +299,19 @@ CUTOFF=%(bash_cutoff)s
 def script_run_falcon_asm(config, las_fofn_fn, preads4falcon_fasta_fn, db_file_fn):
     params = dict(config)
     params.update(locals())
+    def filter_overlap_filtering_setting(val):
+        if '--min_len' not in val and '--min-len' not in val:
+            if 'max_' in val:
+                val += ' --min_len $length_cutoff_pr'
+            else:
+                val += ' --min-len $length_cutoff_pr'
+        return val
+    params['overlap_filtering_setting'] = filter_overlap_filtering_setting(params['overlap_filtering_setting'])
     script = """\
 # Given, las.fofn,
 # write preads.ovl:
-time fc_ovlp_filter --db {db_file_fn} --fofn {las_fofn_fn} {overlap_filtering_setting} --min_len {length_cutoff_pr} >| preads.ovl
+length_cutoff_pr={length_cutoff_pr}
+time fc_ovlp_filter --db {db_file_fn} --fofn {las_fofn_fn} {overlap_filtering_setting} >| preads.ovl
 
 ln -sf {preads4falcon_fasta_fn} ./preads4falcon.fasta
 

--- a/falcon_kit/bash.py
+++ b/falcon_kit/bash.py
@@ -301,7 +301,8 @@ def script_run_falcon_asm(config, las_fofn_fn, preads4falcon_fasta_fn, db_file_f
     params.update(locals())
     def filter_overlap_filtering_setting(val):
         if '--min_len' not in val and '--min-len' not in val:
-            if 'max_' in val:
+            if 'max_' in val or 'n_core' in val:
+                # until we drop the deprecated options
                 val += ' --min_len $length_cutoff_pr'
             else:
                 val += ' --min-len $length_cutoff_pr'
@@ -311,7 +312,7 @@ def script_run_falcon_asm(config, las_fofn_fn, preads4falcon_fasta_fn, db_file_f
 # Given, las.fofn,
 # write preads.ovl:
 length_cutoff_pr={length_cutoff_pr}
-time fc_ovlp_filter --db {db_file_fn} --fofn {las_fofn_fn} {overlap_filtering_setting} >| preads.ovl
+time fc_ovlp_filter {overlap_filtering_setting} {db_file_fn} {las_fofn_fn} >| preads.ovl
 
 ln -sf {preads4falcon_fasta_fn} ./preads4falcon.fasta
 

--- a/falcon_kit/mains/ovlp_filter.py
+++ b/falcon_kit/mains/ovlp_filter.py
@@ -243,7 +243,21 @@ def ovlp_filter(n_core, fofn, max_diff, max_cov, min_cov, min_len, bestn, db_fn,
         Reader = io.StreamedProcessReaderContext
     try_run_ovlp_filter(n_core, fofn, max_diff, max_cov, min_cov, min_len, bestn, db_fn)
 
-def parse_args(argv):
+def quiet_old_parse_args(argv):
+    ostdout = sys.stdout
+    ostderr = sys.stderr
+    sys.stdout = open('/dev/null', 'w')
+    sys.stderr = open('/dev/null', 'w')
+    try:
+        # Trying old command-line parser.
+        return old_parse_args(argv)
+    finally:
+        sys.stdout.close()
+        sys.stderr.close()
+        sys.stdout = ostdout
+        sys.stderr = ostderr
+
+def old_parse_args(argv):
     parser = argparse.ArgumentParser(description='a simple multi-processes LAS ovelap data filter',
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--n_core', type=int, default=4,
@@ -262,6 +276,29 @@ def parse_args(argv):
     args = parser.parse_args(argv[1:])
     return args
 
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description='a simple multi-processes LAS ovelap data filter',
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--n-core', type=int, default=4,
+                        help='number of processes used for generating consensus; '
+                        '0 for main process only')
+    parser.add_argument('--fofn', type=str, required=True, help='file contains the path of all LAS file to be processed in parallel')
+    parser.add_argument('--db', type=str, dest='db_fn', help='read db file path')
+    parser.add_argument('--max-diff', type=int, help="max difference of 5' and 3' coverage")
+    parser.add_argument('--max-ovlp', type=int, dest='max_cov', help="max of 5' or 3' coverage")
+    parser.add_argument('--min-ovlp', type=int, dest='min_cov', help="min of 5' or 3' coverage")
+    parser.add_argument('--min-len', type=int, default=2500, help="min length of the reads")
+    parser.add_argument('--bestn', type=int, default=10, help="output at least best n overlaps on 5' or 3' ends if possible")
+    parser.add_argument('--stream', action='store_true', help='stream from LA4Falcon, instead of slurping all at once; can save memory for large data')
+    parser.add_argument('--debug', '-g', action='store_true', help="single-threaded, plus other aids to debugging")
+    parser.add_argument('--silent', action='store_true', help="suppress cmd reporting on stderr")
+    args = parser.parse_args(argv[1:])
+    return args
+
 def main(argv=sys.argv):
-    args = parse_args(argv)
+    try:
+        args = quiet_old_parse_args(argv)
+        sys.stderr.write('Warning: Using old command-line parser. Run `{} --help` for new options.\n'.format(argv[0]))
+    except:
+        args = parse_args(argv)
     ovlp_filter(**vars(args))

--- a/falcon_kit/mains/ovlp_filter.py
+++ b/falcon_kit/mains/ovlp_filter.py
@@ -232,6 +232,7 @@ def try_run_ovlp_filter(n_core, fofn, max_diff, max_cov, min_cov, min_len, bestn
         exe_pool.terminate()
 
 def ovlp_filter(n_core, fofn, max_diff, max_cov, min_cov, min_len, bestn, db_fn, debug, silent, stream):
+    assert fofn, 'Must provide file-of-filenames for .fastas'
     if debug:
         n_core = 0
         silent = False
@@ -248,7 +249,7 @@ def parse_args(argv):
     parser.add_argument('--n_core', type=int, default=4,
                         help='number of processes used for generating consensus; '
                         '0 for main process only')
-    parser.add_argument('--fofn', type=str, help='file contains the path of all LAS file to be processed in parallel')
+    parser.add_argument('--fofn', type=str, required=True, help='file contains the path of all LAS file to be processed in parallel')
     parser.add_argument('--db', type=str, dest='db_fn', help='read db file path')
     parser.add_argument('--max_diff', type=int, help="max difference of 5' and 3' coverage")
     parser.add_argument('--max_cov', type=int, help="max coverage of 5' or 3' coverage")

--- a/falcon_kit/mains/ovlp_filter.py
+++ b/falcon_kit/mains/ovlp_filter.py
@@ -282,8 +282,6 @@ def parse_args(argv):
     parser.add_argument('--n-core', type=int, default=4,
                         help='number of processes used for generating consensus; '
                         '0 for main process only')
-    parser.add_argument('--fofn', type=str, required=True, help='file contains the path of all LAS file to be processed in parallel')
-    parser.add_argument('--db', type=str, dest='db_fn', help='read db file path')
     parser.add_argument('--max-diff', type=int, help="max difference of 5' and 3' coverage")
     parser.add_argument('--max-ovlp', type=int, dest='max_cov', help="max of 5' or 3' coverage")
     parser.add_argument('--min-ovlp', type=int, dest='min_cov', help="min of 5' or 3' coverage")
@@ -292,6 +290,8 @@ def parse_args(argv):
     parser.add_argument('--stream', action='store_true', help='stream from LA4Falcon, instead of slurping all at once; can save memory for large data')
     parser.add_argument('--debug', '-g', action='store_true', help="single-threaded, plus other aids to debugging")
     parser.add_argument('--silent', action='store_true', help="suppress cmd reporting on stderr")
+    parser.add_argument('db_fn', type=str, help='read db file path')
+    parser.add_argument('fofn', type=str, help='file contains the path of all LAS file to be processed in parallel')
     args = parser.parse_args(argv[1:])
     return args
 


### PR DESCRIPTION
This is a very clean and simple way to deprecate the old options, which would lead to this:
```
Warning: Using old command-line parser. Run with --help for new options.
```
resolves #363