### PR TITLE
Use new simple_pwatcher_bridge.

### DIFF
--- a/falcon_kit/mains/run1.py
+++ b/falcon_kit/mains/run1.py
@@ -4,8 +4,8 @@ from ..util.system import only_these_symlinks
 from pypeflow.pwatcher_bridge import PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase
 from pypeflow.data import makePypeLocalFile, fn
 from pypeflow.task import PypeTask
-#from pypeflow.simple_pwatcher_bridge import (PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase,
-#        makePypeLocalFile, fn, PypeTask)
+from pypeflow.simple_pwatcher_bridge import (PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase,
+        makePypeLocalFile, fn, PypeTask)
 import argparse
 import collections
 import glob


### PR DESCRIPTION
This will turn on the new thing for everyone. I had thought to make it somehow configurable, but I like it enough that I want to switch to it completely. I will do much more testing before a new release anyway. Before then, we also have to look at the default `pwatcher_type`, a setting MJ added last week.