### PR TITLE
Add falcon_greedy option to config

### DIFF
--- a/falcon_kit/bash.py
+++ b/falcon_kit/bash.py
@@ -294,6 +294,8 @@ def script_run_consensus(config, db_fn, las_fn, out_file_bfn):
     params.update(locals())
     if config["falcon_sense_skip_contained"]:
         run_consensus = """LA4Falcon -H$CUTOFF -fso {db_fn} {las_fn} | """
+    elif config["falcon_greedy"]:
+        run_consensus = """LA4Falcon -H$CUTOFF -fog  {db_fn} {las_fn} | """
     else:
         run_consensus = """LA4Falcon -H$CUTOFF -fo  {db_fn} {las_fn} | """
     run_consensus += """fc_consensus {falcon_sense_option} >| {out_file_bfn}"""

--- a/falcon_kit/bash.py
+++ b/falcon_kit/bash.py
@@ -294,7 +294,7 @@ def script_run_consensus(config, db_fn, las_fn, out_file_bfn):
     params.update(locals())
     if config["falcon_sense_skip_contained"]:
         run_consensus = """LA4Falcon -H$CUTOFF -fso {db_fn} {las_fn} | """
-    elif config["falcon_greedy"]:
+    elif config["falcon_sense_greedy"]:
         run_consensus = """LA4Falcon -H$CUTOFF -fog  {db_fn} {las_fn} | """
     else:
         run_consensus = """LA4Falcon -H$CUTOFF -fo  {db_fn} {las_fn} | """

--- a/falcon_kit/run_support.py
+++ b/falcon_kit/run_support.py
@@ -231,19 +231,11 @@ def get_dict_from_old_falcon_cfg(config):
 
     falcon_sense_skip_contained = False
     if config.has_option(section, 'falcon_sense_skip_contained'):
-        falcon_sense_skip_contained = config.get(section, 'falcon_sense_skip_contained')
-        if falcon_sense_skip_contained in ["True", "true", "1"]:
-            falcon_sense_skip_contained = True
-        else:
-            falcon_sense_skip_contained = False
+        falcon_sense_skip_contained = config.getboolean(section, 'falcon_sense_skip_contained')
 
-    falcon_greedy = False
-    if config.has_option(section, 'falcon_greedy'):
-        falcon_greedy = config.get(section, 'falcon_greedy')
-        if falcon_greedy in ["True", "true", "1"]:
-            falcon_greedy = True
-        else:
-            falcon_greedy = False
+    falcon_sense_greedy = False
+    if config.has_option(section, 'falcon_sense_greedy'):
+        falcon_sense_greedy = config.getboolean(section, 'falcon_sense_greedy')
 
     genome_size = 0
     if config.has_option(section, 'genome_size'):
@@ -336,7 +328,7 @@ def get_dict_from_old_falcon_cfg(config):
                    "fc_ovlp_to_graph_option": fc_ovlp_to_graph_option,
                    "falcon_sense_option": falcon_sense_option,
                    "falcon_sense_skip_contained": falcon_sense_skip_contained,
-                   "falcon_greedy": falcon_greedy,
+                   "falcon_sense_greedy": falcon_sense_greedy,
                    "stop_all_jobs_on_failure": stop_all_jobs_on_failure,
                    "use_tmpdir": use_tmpdir,
                    "pwatcher_type": pwatcher_type,

--- a/falcon_kit/run_support.py
+++ b/falcon_kit/run_support.py
@@ -237,6 +237,14 @@ def get_dict_from_old_falcon_cfg(config):
         else:
             falcon_sense_skip_contained = False
 
+    falcon_greedy = False
+    if config.has_option(section, 'falcon_greedy'):
+        falcon_greedy = config.get(section, 'falcon_greedy')
+        if falcon_greedy in ["True", "true", "1"]:
+            falcon_greedy = True
+        else:
+            falcon_greedy = False
+
     genome_size = 0
     if config.has_option(section, 'genome_size'):
         genome_size = config.getint(section, 'genome_size')
@@ -328,6 +336,7 @@ def get_dict_from_old_falcon_cfg(config):
                    "fc_ovlp_to_graph_option": fc_ovlp_to_graph_option,
                    "falcon_sense_option": falcon_sense_option,
                    "falcon_sense_skip_contained": falcon_sense_skip_contained,
+                   "falcon_greedy": falcon_greedy,
                    "stop_all_jobs_on_failure": stop_all_jobs_on_failure,
                    "use_tmpdir": use_tmpdir,
                    "pwatcher_type": pwatcher_type,


### PR DESCRIPTION
When falcon_greedy is turned on, 'LA4Falcon -fog'
instead of 'LA4Falcon -fo' will be used.