### PR TITLE
Scatter/gather tasks

### DIFF
--- a/falcon_kit/bash.py
+++ b/falcon_kit/bash.py
@@ -267,17 +267,17 @@ def scripts_merge(config, db_prefix, run_jobs_fn):
     """
     with open(run_jobs_fn) as f:
         mjob_data = functional.get_mjob_data(f)
+    #las_fns = functional.get_las_filenames(mjob_data, db_prefix) # ok, but tricky
     for p_id in mjob_data:
         bash_lines = mjob_data[p_id]
 
         script = []
         for line in bash_lines:
             script.append(line.replace('&&', ';'))
-        #script.append("mkdir -p ../las_files")
-        #script.append("ln -sf ../m_%05d/%s.%s.las ../las_files" % (p_id, db_prefix, p_id))
-        #script.append("ln -sf ./m_%05d/%s.%s.las .. " % (p_id, db_prefix, p_id))
-        #las_fn = '%s.%s.las' % (db_prefix, p_id))
-        yield p_id, '\n'.join(script + [''])
+        #las_fn = las_fns[p_id]
+        # We already know the output .las filename by convention.
+        las_fn = '%s.%s.las' % (db_prefix, p_id)
+        yield p_id, '\n'.join(script + ['']), las_fn
 
 def script_run_consensus(config, db_fn, las_fn, out_file_bfn):
     """config: falcon_sense_option, length_cutoff

--- a/falcon_kit/functional.py
+++ b/falcon_kit/functional.py
@@ -137,6 +137,45 @@ def first_block_las(line):
         raise Exception('Pattern {!r} does not match line {!r}: {}'.format(
             re_first_block_las.pattern, line, e))
 
+def get_las_filenames(mjob_data, db_prefix):
+    """Given result of get_mjob_data(),
+    return {int: final_las_filename}
+    """
+    # This is our best guess.
+    # (We might not even need this, since we know the output filename of each merge-task by convention.)
+    # Eventually, we need to re-write HPC.daligner.
+    result = {}
+    re_LAmerge = re.compile(r'^LAmerge\s+(?:\-\S+\s+)(\S+)')
+    re_LAcheck = re.compile(r'^LAcheck\s+(?:\-\S+\s+)\S+\s+(\S+)')
+    for p_id, bash_lines in mjob_data.iteritems():
+        if not bash_lines:
+            # The daligner+LAsort+LAmerge job produced the final .las
+            # for this block. We will symlink it later.
+            las_fn = '{}.{}.las'.format(db_prefix, p_id)
+            result[p_id] = las_fn
+            continue
+        # Find the last line which can tell us the final .las name.
+        i = len(bash_lines) - 1
+        while bash_lines[i].split()[0] not in ('LAmerge', 'LAcheck'):
+            i -= 1
+        # Now we will raise an exception if there were none. But in theory, there
+        # must be at least an LAsort.
+        first_word = bash_lines[i].split()[0]
+        if first_word == 'LAmerge':
+            regex = re_LAmerge
+        elif first_word == 'LAcheck':
+            regex = re_LAcheck
+        else:
+            raise Exception('first_word={!r} in line#{} of {!r}'.format(
+                first_word, i, bash_lines))
+        mo = regex.search(bash_lines[i])
+        if not mo:
+            raise Exception('Regex {!r} failed on {!r}'.format(
+                re_las_name.pattern, bash_lines[i]))
+        las_fn = mo.group(1) + '.las'
+        result[p_id] = las_fn
+    return result
+
 def get_mjob_data(run_jobs_stream):
     """Given output of HPC.daligner,
     return {int: [bash-lines]}

--- a/falcon_kit/mains/run1.py
+++ b/falcon_kit/mains/run1.py
@@ -1,5 +1,5 @@
 from .. import run_support as support
-from .. import bash
+from .. import bash, pype_tasks
 from ..util.system import only_these_symlinks
 from pypeflow.pwatcher_bridge import PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase
 from pypeflow.data import makePypeLocalFile, fn
@@ -7,7 +7,6 @@ from pypeflow.task import PypeTask
 from pypeflow.simple_pwatcher_bridge import (PypeProcWatcherWorkflow, MyFakePypeThreadTaskBase,
         makePypeLocalFile, fn, PypeTask)
 import argparse
-import collections
 import glob
 import json
 import logging
@@ -18,291 +17,6 @@ import time
 
 
 fc_run_logger = logging.getLogger(__name__) # default, for remote tasks
-
-def remove(*fns):
-    for fn in fns:
-        if os.path.exists(fn):
-            os.remove(fn)
-        assert not os.path.exists(fn)
-
-def system(call, check=False):
-    fc_run_logger.debug('$(%s)' %repr(call))
-    rc = os.system(call)
-    msg = "Call %r returned %d." % (call, rc)
-    if rc:
-        fc_run_logger.warning(msg)
-        if check:
-            raise Exception(msg)
-    else:
-        fc_run_logger.debug(msg)
-    return rc
-
-def task_make_fofn_abs_raw(self):
-    script_fn = 'noop.sh'
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
-    mkdir(os.path.dirname(fn(self.o_fofn)))
-    support.make_fofn_abs(fn(self.i_fofn), fn(self.o_fofn))
-
-def task_make_fofn_abs_preads(self):
-    script_fn = 'noop.sh'
-    open(script_fn, 'w').write('echo NOOP preads')
-    self.generated_script_fn = script_fn
-    mkdir(os.path.dirname(fn(self.o_fofn)))
-    support.make_fofn_abs(fn(self.i_fofn), fn(self.o_fofn))
-
-def task_build_rdb(self):
-    input_fofn_fn = fn(self.input_fofn)
-    job_done = fn(self.rdb_build_done)
-    db = fn(self.raw_reads_db)
-    run_jobs = fn(self.run_jobs)
-    remove(job_done, db, run_jobs)
-    work_dir = self.parameters["work_dir"]
-    config = self.parameters["config"]
-
-    script_fn = os.path.join( work_dir, "prepare_rdb.sh" )
-    args = {
-        'input_fofn_fn': input_fofn_fn,
-        'config': config,
-        'job_done': job_done,
-        'script_fn': script_fn,
-        'run_jobs_fn': run_jobs,
-    }
-    support.build_rdb(**args)
-    self.generated_script_fn = script_fn
-
-def task_build_pdb(self):  #essential the same as build_rdb() but the subtle differences are tricky to consolidate to one function
-    input_fofn_fn = fn(self.preads_fofn)
-    job_done = fn(self.pdb_build_done)
-    db = fn(self.preads_db)
-    run_jobs = fn(self.run_jobs)
-    remove(job_done, db, run_jobs)
-    work_dir = self.parameters["work_dir"]
-    config = self.parameters["config"]
-
-    script_fn = os.path.join( work_dir, "prepare_pdb.sh" )
-    args = {
-        'input_fofn_fn': input_fofn_fn,
-        'config': config,
-        'job_done': job_done,
-        'script_fn': script_fn,
-        'run_jobs_fn': run_jobs,
-    }
-    support.build_pdb(**args)
-    self.generated_script_fn = script_fn
-
-def task_run_db2falcon(self):
-    wd = self.parameters["wd"]
-    mkdir(wd)
-    #self.p_merge_done
-    job_done = fn(self.db2falcon_done)
-    preads4falcon_fn = fn(self.preads4falcon)
-    preads_db = fn(self.preads_db)
-    config = self.parameters["config"]
-    script_dir = os.path.join(wd)
-    script_fn = os.path.join(script_dir ,"run_db2falcon.sh")
-    args = {
-        'config': config,
-        'job_done': job_done,
-        'script_fn': script_fn,
-        'preads4falcon_fn': preads4falcon_fn,
-        'preads_db': preads_db,
-    }
-    support.run_db2falcon(**args)
-    self.generated_script_fn = script_fn
-
-def task_run_falcon_asm(self):
-    wd = self.parameters["wd"]
-    #self.db2falcon_done
-    db_file = fn(self.db_file)
-    job_done = fn(self.falcon_asm_done)
-    config = self.parameters["config"]
-    pread_dir = self.parameters["pread_dir"]
-    preads4falcon_fn = fn(self.preads4falcon)
-    script_dir = os.path.join( wd )
-    script_fn =  os.path.join( script_dir ,"run_falcon_asm.sh" )
-    # Generate las.fofn in run-dir.
-    system('cd {}; find {}/m_*/ -name "preads.*.las" >| las.fofn'.format(wd, pread_dir))
-    las_fofn_fn = 'las.fofn'
-    args = {
-        'las_fofn_fn': las_fofn_fn,
-        'preads4falcon_fasta_fn': preads4falcon_fn,
-        'db_file_fn': db_file,
-        'config': config,
-        'job_done': job_done,
-        'script_fn': script_fn,
-    }
-    support.run_falcon_asm(**args)
-    self.generated_script_fn = script_fn
-
-def task_report_pre_assembly(self):
-    # TODO(CD): Bashify this, in case it is slow.
-    i_raw_reads_db_fn = fn(self.raw_reads_db)
-    i_preads_fofn_fn = fn(self.preads_fofn)
-    i_length_cutoff_fn = fn(self.length_cutoff_fn)
-    o_json_fn = fn(self.pre_assembly_report)
-    cfg = self.parameters
-    genome_length = int(cfg.get('genome_size', 0)) # different name in falcon
-    length_cutoff = int(cfg['length_cutoff'])
-    # Update length_cutoff if auto-calc (when length_cutoff is negative).
-    # i_length_cutoff_fn was created long ago, so no filesystem issues.
-    length_cutoff = support.get_length_cutoff(length_cutoff, i_length_cutoff_fn)
-    cwd = self.parameters['cwd']
-    mkdir(cwd)
-    script_fn = os.path.join(cwd , 'run_report_pre_assembly.sh')
-    job_done = os.path.join(cwd, 'report_pa_done')
-    kwds = {
-        'i_raw_reads_db_fn': i_raw_reads_db_fn,
-        'i_preads_fofn_fn': i_preads_fofn_fn,
-        'genome_length': genome_length,
-        'length_cutoff': length_cutoff,
-        'o_json_fn': o_json_fn,
-        'job_done': job_done,
-        'script_fn': script_fn,
-    }
-    fc_run_logger.info('Report inputs: {}'.format(repr(kwds)))
-    support.run_report_pre_assembly(**kwds)
-    self.generated_script_fn = script_fn
-
-def task_run_daligner(self):
-    job_done = fn(self.job_done)
-    daligner_script = self.parameters["daligner_script"]
-    job_uid = self.parameters["job_uid"]
-    cwd = self.parameters["cwd"]
-    mkdir(cwd)
-    db_prefix = self.parameters["db_prefix"]
-    config = self.parameters["config"]
-    script_dir = os.path.join(cwd)
-    script_fn =  os.path.join(script_dir , "rj_%s.sh" % (job_uid))
-    args = {
-        'daligner_script': daligner_script,
-        'db_prefix': db_prefix,
-        'config': config,
-        'job_done': job_done,
-        'script_fn': script_fn,
-    }
-    support.run_daligner(**args)
-    self.generated_script_fn = script_fn
-
-def read_gathered_las(path):
-    """Return dict of block->[las_paths].
-    For now, these are ws separated on each line of input.
-    """
-    result = collections.defaultdict(list)
-    with open(path) as ifs:
-        for line in ifs:
-            block, las_path = line.split()
-            result[int(block)].append(las_path)
-    #fc_run_logger.warning('path={!r}, result={}'.format(
-    #    path, pprint.pformat(result)))
-    return result
-
-def task_run_las_merge(self):
-    gathered_las_fn = fn(self.gathered_las)
-    script = self.parameters["merge_script"]
-    job_id = self.parameters["job_id"] # aka "block"
-    cwd = self.parameters["cwd"]
-    mkdir(cwd)
-
-    gathered_dict = read_gathered_las(gathered_las_fn)
-    las_paths = gathered_dict[job_id]
-    for las_path in las_paths:
-        src = os.path.relpath(las_path, cwd)
-        tgt = os.path.join(cwd, os.path.basename(las_path))
-        fc_run_logger.debug('symlink {!r} -> {!r}'.format(src, tgt))
-        os.symlink(src, tgt)
-
-    job_done = fn(self.job_done)
-    config = self.parameters["config"]
-
-    script_dir = os.path.join( cwd )
-    script_fn =  os.path.join( script_dir , "rp_%05d.sh" % (job_id))
-    args = {
-        'script': script,
-        'config': config,
-        'job_done': job_done,
-        'script_fn': script_fn,
-    }
-    support.run_las_merge(**args)
-    self.generated_script_fn = script_fn
-
-def task_run_consensus(self):
-    merge_job_done = fn(self.job_done)
-    out_file_fn = fn(self.out_file)
-    out_done = fn(self.out_done)
-    job_id = self.parameters["job_id"]
-    cwd = self.parameters["cwd"]
-    config = self.parameters["config"]
-    prefix = self.parameters["prefix"]
-    script_dir = os.path.join( cwd )
-    script_fn =  os.path.join( script_dir , "c_%05d.sh" % (job_id))
-    db_fn = os.path.abspath('{cwd}/../../{prefix}'.format(**locals())) # ASSUMING 2-levels deep
-    merge_job_dir = os.path.dirname(merge_job_done)
-    # by convention, we assume the name of the .las file
-    las_fn = os.path.abspath('{merge_job_dir}/{prefix}.{job_id}.las'.format(**locals()))
-    args = {
-        'db_fn': db_fn,
-        'las_fn': las_fn,
-        'out_file_fn': out_file_fn,
-        'config': config,
-        'job_done': out_done,
-        'script_fn': script_fn,
-    }
-    support.run_consensus(**args)
-    self.generated_script_fn = script_fn
-
-def mkdir(d):
-    if not os.path.isdir(d):
-        os.makedirs(d)
-
-def task_daligner_gather(self):
-    """Find all .las leaves so far.
-    """
-    out_dict = self.inputs
-    gathered_fn = fn(self.gathered)
-    nblock = self.parameters['nblock']
-    fc_run_logger.debug('nblock=%d, out_dir:\n%s'%(nblock, out_dict))
-    job_rundirs = [os.path.dirname(fn(dal_done)) for dal_done in out_dict.values()]
-    wdir = os.path.dirname(gathered_fn)
-    mkdir(wdir)
-    with open(gathered_fn, 'w') as ofs:
-        for block, las_path in support.daligner_gather_las(job_rundirs):
-            ofs.write('{} {}\n'.format(block, las_path))
-
-    # Because we need a script always, for now.
-    script_fn = os.path.join(wdir, 'noop.sh')
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
-def old_task_daligner_gather(self):
-    """Create symlinks in the m_* directories.
-    Kinda messy, and it must run in the base-dir for now.
-    """
-    da_done = fn(self.da_done)
-    main_dir = os.path.dirname(da_done)
-    out_dict = self.inputs
-    nblock = self.parameters['nblock']
-    fc_run_logger.debug('nblock=%d, out_dir:\n%s'%(nblock, out_dict))
-
-    # Create m_* dirs.
-    for block in xrange(1, nblock+1):
-        mdir = os.path.join(main_dir, 'm_%05d' %block) # By convention. pbsmrtpipe works differently.
-        mkdir(mdir)
-        # TODO: Remove existing symlinks?
-    job_rundirs = [os.path.dirname(fn(dal_done)) for dal_done in out_dict.values()]
-
-    # Symlink all daligner *.las.
-    links = collections.defaultdict(list)
-    for block, las_path in support.daligner_gather_las(job_rundirs):
-            mdir = os.path.join(main_dir, 'm_%05d' %block) # By convention. pbsmrtpipe works differently.
-            #las_path = os.path.relpath(las_path, mdir)
-            links[mdir].append(las_path)
-    only_these_symlinks(links)
-    system("touch %s" %da_done)
-
-    # Because we need a script always, for now.
-    script_fn = 'noop.sh'
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
 
 def create_daligner_tasks(run_jobs_fn, wd, db_prefix, rdb_build_done, nblock, config, pread_aln=False):
     tasks = []
@@ -325,7 +39,7 @@ def create_daligner_tasks(run_jobs_fn, wd, db_prefix, rdb_build_done, nblock, co
                                       parameters = parameters,
                                       TaskType = MyFakePypeThreadTaskBase,
                                       URL = "task://localhost/d_%s_%s" %(job_uid, db_prefix))
-        daligner_task = make_daligner_task(task_run_daligner)
+        daligner_task = make_daligner_task(pype_tasks.task_run_daligner)
         tasks.append(daligner_task)
         tasks_out[ "ajob_%s" % job_uid ] = job_done
     return tasks, tasks_out
@@ -350,7 +64,7 @@ def create_merge_tasks(run_jobs_fn, wd, db_prefix, gathered_las_plf, config):
                                    parameters = parameters,
                                    TaskType = MyFakePypeThreadTaskBase,
                                    URL = "task://localhost/m_%05d_%s" % (p_id, db_prefix))
-        merge_task = make_merge_task(task_run_las_merge)
+        merge_task = make_merge_task(pype_tasks.task_run_las_merge)
         merge_out["mjob_%d" % p_id] = job_done
         merge_tasks.append(merge_task)
         p_ids_merge_job_done.append((p_id, job_done))
@@ -363,7 +77,6 @@ def create_consensus_tasks(wd, db_prefix, config, p_ids_merge_job_done):
     for p_id, job_done in p_ids_merge_job_done:
         cns_label = 'cns_%05d' %p_id
         rdir = os.path.join(wd, 'preads', cns_label)
-        mkdir(rdir)
         out_done = makePypeLocalFile(os.path.abspath("%s/%s_done" % (rdir, cns_label)))
         out_file = makePypeLocalFile(os.path.abspath("%s/%s.fasta" % (rdir, cns_label)))
         fasta_plfs.append(out_file)
@@ -377,7 +90,7 @@ def create_consensus_tasks(wd, db_prefix, config, p_ids_merge_job_done):
                                parameters = parameters,
                                TaskType = MyFakePypeThreadTaskBase,
                                URL = "task://localhost/%s" % cns_label)
-        c_task = make_c_task(task_run_consensus)
+        c_task = make_c_task(pype_tasks.task_run_consensus)
         consensus_tasks.append(c_task)
         #consensus_out["cjob_%d" % p_id] = out_done
         consensus_out["cjob_%d" % p_id] = out_file
@@ -390,27 +103,8 @@ def create_consensus_tasks(wd, db_prefix, config, p_ids_merge_job_done):
                 outputs =  {"cns_done":r_cns_done_plf, "preads_fofn": preads_fofn_plf},
                 TaskType = MyFakePypeThreadTaskBase,
                 URL = "task://localhost/cns_check" )
-    consensus_tasks.append(make_check_r_cns_task(check_r_cns_task))
+    consensus_tasks.append(make_check_r_cns_task(pype_tasks.check_r_cns_task))
     return consensus_tasks, preads_fofn_plf
-
-# PypeTask functions now need to be module-level.
-def check_r_cns_task(self):
-    with open(fn(self.preads_fofn),  "w") as f:
-        for fa_fn in sorted(fn(plf) for plf in self.inputs.values()):
-            print >>f, fa_fn
-    wdir = os.path.dirname(fn(self.cns_done))
-    #mkdir(wdir) We SHOULD need this! TODO
-    system("touch %s" % fn(self.cns_done))
-    script_fn = os.path.join(wdir, 'noop.sh')
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
-def check_p_merge_check_task(self):
-    wdir = os.path.dirname(fn(self.p_merge_done))
-    mkdir(wdir)
-    system("touch %s" % fn(self.p_merge_done))
-    script_fn = os.path.join(wdir, 'noop.sh')
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
 
 
 def main1(prog_name, input_config_fn, logger_config_fn=None):
@@ -464,7 +158,7 @@ def run(wf, config,
                                   outputs = {"o_fofn": rawread_fofn_plf},
                                   parameters = {},
                                   TaskType = MyFakePypeThreadTaskBase)
-    fofn_abs_task = make_fofn_abs_task(task_make_fofn_abs_raw)
+    fofn_abs_task = make_fofn_abs_task(pype_tasks.task_make_fofn_abs_raw)
 
     wf.addTasks([fofn_abs_task])
     wf.refreshTargets([fofn_abs_task])
@@ -489,7 +183,7 @@ def run(wf, config,
                                       },
                                       parameters = parameters,
                                       TaskType = MyFakePypeThreadTaskBase)
-        build_rdb_task = make_build_rdb_task(task_build_rdb)
+        build_rdb_task = make_build_rdb_task(pype_tasks.task_build_rdb)
 
         wf.addTasks([build_rdb_task])
         wf.refreshTargets([rdb_build_done])
@@ -511,7 +205,7 @@ def run(wf, config,
                    parameters = parameters,
                    TaskType = MyFakePypeThreadTaskBase,
                    URL = "task://localhost/rda_check" )
-        check_r_da_task = make_daligner_gather(task_daligner_gather)
+        check_r_da_task = make_daligner_gather(pype_tasks.task_daligner_gather)
         wf.addTask(check_r_da_task)
         wf.refreshTargets(exitOnFailure=exitOnFailure)
 
@@ -536,7 +230,7 @@ def run(wf, config,
                 parameters = parameters,
                 TaskType = MyFakePypeThreadTaskBase,
                 URL = "task://localhost/report_pre_assembly")
-        task = make_task(task_report_pre_assembly)
+        task = make_task(pype_tasks.task_report_pre_assembly)
         wf.addTask(task)
 
         concurrent_jobs = config["cns_concurrent_jobs"]
@@ -555,7 +249,7 @@ def run(wf, config,
                                      outputs = {"o_fofn": preads_fofn_plf},
                                      parameters = {},
                                      TaskType = MyFakePypeThreadTaskBase)
-        fofn_abs_task = make_fofn_abs_task(task_make_fofn_abs_preads)
+        fofn_abs_task = make_fofn_abs_task(pype_tasks.task_make_fofn_abs_preads)
         wf.addTasks([fofn_abs_task])
         wf.refreshTargets([fofn_abs_task])
 
@@ -575,7 +269,7 @@ def run(wf, config,
                                     parameters = parameters,
                                     TaskType = MyFakePypeThreadTaskBase,
                                     URL = "task://localhost/build_pdb")
-    build_pdb_task = make_build_pdb_task(task_build_pdb)
+    build_pdb_task = make_build_pdb_task(pype_tasks.task_build_pdb)
 
     wf.addTasks([build_pdb_task])
     wf.refreshTargets([pdb_build_done])
@@ -598,7 +292,7 @@ def run(wf, config,
                 parameters = parameters,
                 TaskType = MyFakePypeThreadTaskBase,
                 URL = "task://localhost/pda_check" )
-    check_p_da_task = make_daligner_gather(task_daligner_gather)
+    check_p_da_task = make_daligner_gather(pype_tasks.task_daligner_gather)
     wf.addTask(check_p_da_task)
     wf.refreshTargets(exitOnFailure=exitOnFailure)
 
@@ -612,7 +306,7 @@ def run(wf, config,
                outputs =  {"p_merge_done": p_merge_done},
                TaskType = MyFakePypeThreadTaskBase,
                URL = "task://localhost/pmerge_check" )
-    wf.addTask(make_check_p_merge_task(check_p_merge_check_task))
+    wf.addTask(make_check_p_merge_task(pype_tasks.check_p_merge_check_task))
 
     concurrent_jobs = config["ovlp_concurrent_jobs"]
     setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
@@ -636,7 +330,7 @@ def run(wf, config,
                             },
                TaskType = MyFakePypeThreadTaskBase,
                URL = "task://localhost/db2falcon" )
-    wf.addTask(make_run_db2falcon(task_run_db2falcon))
+    wf.addTask(make_run_db2falcon(pype_tasks.task_run_db2falcon))
 
     falcon_asm_done = makePypeLocalFile( os.path.join(falcon_asm_dir, 'falcon_asm_done'))
     make_run_falcon_asm = PypeTask(
@@ -651,7 +345,7 @@ def run(wf, config,
                },
                TaskType = MyFakePypeThreadTaskBase,
                URL = "task://localhost/falcon_asm" )
-    wf.addTask(make_run_falcon_asm(task_run_falcon_asm))
+    wf.addTask(make_run_falcon_asm(pype_tasks.task_run_falcon_asm))
     wf.refreshTargets()
 
     return falcon_asm_done

--- a/falcon_kit/mains/run1.py
+++ b/falcon_kit/mains/run1.py
@@ -40,7 +40,7 @@ def create_daligner_tasks(basedir, scatter_fn):
         )
         daligner_task = make_daligner_task(pype_tasks.task_run_daligner)
         tasks.append(daligner_task)
-        tasks_out[ "ajob_%s" % job_uid ] = daligner_task.outputs['job_done'] # these are relative, so we need the PypeLocalFiles
+        tasks_out['ajob_%s' % job_uid] = daligner_task.outputs['job_done'] # these are relative, so we need the PypeLocalFiles
     return tasks, tasks_out
 
 def create_merge_tasks(basedir, scatter_fn):
@@ -94,7 +94,7 @@ def create_consensus_tasks(basedir, scatter_fn):
         )
         c_task = make_c_task(pype_tasks.task_run_consensus)
         consensus_tasks.append(c_task)
-        consensus_out["cjob_%d" % p_id] = outputs['out_file']
+        consensus_out['cjob_%d' % p_id] = outputs['out_file']
     return consensus_tasks, consensus_out
 
 def create_consensus_gather_task(wd, consensus_out):
@@ -105,7 +105,7 @@ def create_consensus_gather_task(wd, consensus_out):
                 inputs = consensus_out,
                 outputs =  {'cns_done': r_cns_done_plf, 'preads_fofn': preads_fofn_plf},
                 TaskType = MyFakePypeThreadTaskBase,
-                URL = "task://localhost/cns_gather" )
+                URL = 'task://localhost/cns_gather' )
     task = make_cns_gather_task(pype_tasks.task_cns_gather)
     return task, preads_fofn_plf
 
@@ -114,13 +114,13 @@ def main1(prog_name, input_config_fn, logger_config_fn=None):
     global fc_run_logger
     fc_run_logger = support.setup_logger(logger_config_fn)
 
-    fc_run_logger.info("fc_run started with configuration %s", input_config_fn)
+    fc_run_logger.info('fc_run started with configuration %s', input_config_fn)
     try:
         config = support.get_dict_from_old_falcon_cfg(support.parse_config(input_config_fn))
     except Exception:
         fc_run_logger.exception('Failed to parse config "{}".'.format(input_config_fn))
         raise
-    input_fofn_plf = makePypeLocalFile(config["input_fofn"])
+    input_fofn_plf = makePypeLocalFile(config['input_fofn'])
     #Workflow = PypeProcWatcherWorkflow
     wf = PypeProcWatcherWorkflow(job_type=config['job_type'],
             job_queue=config['job_queue'],
@@ -143,22 +143,22 @@ def run(wf, config,
     * fc_run_logger
     * run_support.logger
     """
-    rawread_dir = os.path.abspath("./0-rawreads")
-    pread_dir = os.path.abspath("./1-preads_ovl")
-    falcon_asm_dir  = os.path.abspath("./2-asm-falcon")
-    script_dir = os.path.abspath("./scripts")
-    sge_log_dir = os.path.abspath("./sge_log")
+    rawread_dir = os.path.abspath('./0-rawreads')
+    pread_dir = os.path.abspath('./1-preads_ovl')
+    falcon_asm_dir  = os.path.abspath('./2-asm-falcon')
+    script_dir = os.path.abspath('./scripts')
+    sge_log_dir = os.path.abspath('./sge_log')
 
     for d in (rawread_dir, pread_dir, falcon_asm_dir, script_dir, sge_log_dir):
         support.make_dirs(d)
 
     exitOnFailure=config['stop_all_jobs_on_failure'] # only matter for parallel jobs
-    concurrent_jobs = config["pa_concurrent_jobs"]
+    concurrent_jobs = config['pa_concurrent_jobs']
     setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
 
-    rawread_fofn_plf = makePypeLocalFile(os.path.join(rawread_dir, 'raw-fofn-abs', os.path.basename(config["input_fofn"])))
-    make_fofn_abs_task = PypeTask(inputs = {"i_fofn": input_fofn_plf},
-                                  outputs = {"o_fofn": rawread_fofn_plf},
+    rawread_fofn_plf = makePypeLocalFile(os.path.join(rawread_dir, 'raw-fofn-abs', os.path.basename(config['input_fofn'])))
+    make_fofn_abs_task = PypeTask(inputs = {'i_fofn': input_fofn_plf},
+                                  outputs = {'o_fofn': rawread_fofn_plf},
                                   parameters = {},
                                   TaskType = MyFakePypeThreadTaskBase)
     fofn_abs_task = make_fofn_abs_task(pype_tasks.task_make_fofn_abs_raw)
@@ -166,23 +166,23 @@ def run(wf, config,
     wf.addTasks([fofn_abs_task])
     wf.refreshTargets([fofn_abs_task])
 
-    if config["input_type"] == "raw":
+    if config['input_type'] == 'raw':
         #### import sequences into daligner DB
-        sleep_done = makePypeLocalFile( os.path.join( rawread_dir, "sleep_done") )
-        rdb_build_done = makePypeLocalFile( os.path.join( rawread_dir, "rdb_build_done") )
-        run_jobs = makePypeLocalFile( os.path.join( rawread_dir, "run_jobs.sh") )
-        parameters = {"work_dir": rawread_dir,
-                      "sge_option": config["sge_option_da"],
-                      "config_fn": input_config_fn,
-                      "config": config}
+        sleep_done = makePypeLocalFile( os.path.join( rawread_dir, 'sleep_done') )
+        rdb_build_done = makePypeLocalFile( os.path.join( rawread_dir, 'rdb_build_done') )
+        run_jobs = makePypeLocalFile( os.path.join( rawread_dir, 'run_jobs.sh') )
+        parameters = {'work_dir': rawread_dir,
+                      'sge_option': config['sge_option_da'],
+                      'config_fn': input_config_fn,
+                      'config': config}
 
-        length_cutoff_plf = makePypeLocalFile(os.path.join(rawread_dir, "length_cutoff"))
-        raw_reads_db_plf = makePypeLocalFile(os.path.join(rawread_dir, "%s.db" % "raw_reads"))
-        make_build_rdb_task = PypeTask(inputs = {"input_fofn": rawread_fofn_plf},
-                                      outputs = {"rdb_build_done": rdb_build_done,
-                                                 "raw_reads_db": raw_reads_db_plf,
-                                                 "length_cutoff": length_cutoff_plf,
-                                                 "run_jobs": run_jobs,
+        length_cutoff_plf = makePypeLocalFile(os.path.join(rawread_dir, 'length_cutoff'))
+        raw_reads_db_plf = makePypeLocalFile(os.path.join(rawread_dir, '%s.db' % 'raw_reads'))
+        make_build_rdb_task = PypeTask(inputs = {'input_fofn': rawread_fofn_plf},
+                                      outputs = {'rdb_build_done': rdb_build_done,
+                                                 'raw_reads_db': raw_reads_db_plf,
+                                                 'length_cutoff': length_cutoff_plf,
+                                                 'run_jobs': run_jobs,
                                       },
                                       parameters = parameters,
                                       TaskType = MyFakePypeThreadTaskBase)
@@ -221,14 +221,14 @@ def run(wf, config,
         r_gathered_las_plf = makePypeLocalFile(os.path.join(rawread_dir, 'raw-gather', 'gathered_las.txt'))
 
         parameters =  {
-                "nblock": raw_reads_nblock,
+                'nblock': raw_reads_nblock,
         }
         make_daligner_gather = PypeTask(
                    inputs = daligner_out,
-                   outputs =  {"gathered": r_gathered_las_plf},
+                   outputs =  {'gathered': r_gathered_las_plf},
                    parameters = parameters,
                    TaskType = MyFakePypeThreadTaskBase,
-                   URL = "task://localhost/rda_check" )
+                   URL = 'task://localhost/rda_check' )
         check_r_da_task = make_daligner_gather(pype_tasks.task_daligner_gather)
         wf.addTask(check_r_da_task)
         wf.refreshTargets(exitOnFailure=exitOnFailure)
@@ -258,7 +258,7 @@ def run(wf, config,
         wf.addTasks(merge_tasks)
         wf.refreshTargets(exitOnFailure=exitOnFailure)
 
-        if config["target"] == "overlapping":
+        if config['target'] == 'overlapping':
             sys.exit(0)
 
         # Produce new FOFN of preads fasta, based on consensus of overlaps.
@@ -291,52 +291,52 @@ def run(wf, config,
         parameters = dict(config)
         parameters['cwd'] = rdir
         make_task = PypeTask(
-                inputs = {"length_cutoff_fn": length_cutoff_plf,
-                          "raw_reads_db": raw_reads_db_plf,
-                          "preads_fofn": preads_fofn_plf, },
-                outputs = {"pre_assembly_report": pre_assembly_report_plf, },
+                inputs = {'length_cutoff_fn': length_cutoff_plf,
+                          'raw_reads_db': raw_reads_db_plf,
+                          'preads_fofn': preads_fofn_plf, },
+                outputs = {'pre_assembly_report': pre_assembly_report_plf, },
                 parameters = parameters,
                 TaskType = MyFakePypeThreadTaskBase,
-                URL = "task://localhost/report_pre_assembly")
+                URL = 'task://localhost/report_pre_assembly')
         task = make_task(pype_tasks.task_report_pre_assembly)
         wf.addTask(task)
 
-        concurrent_jobs = config["cns_concurrent_jobs"]
+        concurrent_jobs = config['cns_concurrent_jobs']
         setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
         wf.refreshTargets(exitOnFailure=exitOnFailure)
 
 
-    if config["target"] == "pre-assembly":
-        log.info("Quitting after stage-0 for 'pre-assembly' target.")
+    if config['target'] == 'pre-assembly':
+        log.info('Quitting after stage-0 for "pre-assembly" target.')
         sys.exit(0)
 
     # build pread database
-    if config["input_type"] == "preads":
-        preads_fofn_plf = makePypeLocalFile(os.path.join(pread_dir, 'preads-fofn-abs', os.path.basename(config["input_fofn"])))
-        make_fofn_abs_task = PypeTask(inputs = {"i_fofn": rawread_fofn_plf},
-                                     outputs = {"o_fofn": preads_fofn_plf},
+    if config['input_type'] == 'preads':
+        preads_fofn_plf = makePypeLocalFile(os.path.join(pread_dir, 'preads-fofn-abs', os.path.basename(config['input_fofn'])))
+        make_fofn_abs_task = PypeTask(inputs = {'i_fofn': rawread_fofn_plf},
+                                     outputs = {'o_fofn': preads_fofn_plf},
                                      parameters = {},
                                      TaskType = MyFakePypeThreadTaskBase)
         fofn_abs_task = make_fofn_abs_task(pype_tasks.task_make_fofn_abs_preads)
         wf.addTasks([fofn_abs_task])
         wf.refreshTargets([fofn_abs_task])
 
-    pdb_build_done = makePypeLocalFile( os.path.join( pread_dir, "pdb_build_done") )
-    parameters = {"work_dir": pread_dir,
-                  "sge_option": config["sge_option_pda"],
-                  "config_fn": input_config_fn,
-                  "config": config}
+    pdb_build_done = makePypeLocalFile( os.path.join( pread_dir, 'pdb_build_done') )
+    parameters = {'work_dir': pread_dir,
+                  'sge_option': config['sge_option_pda'],
+                  'config_fn': input_config_fn,
+                  'config': config}
 
     run_jobs = makePypeLocalFile(os.path.join(pread_dir, 'run_jobs.sh'))
     preads_db = makePypeLocalFile(os.path.join(pread_dir, 'preads.db')) # Also .preads.*, of course.
-    make_build_pdb_task  = PypeTask(inputs = {"preads_fofn": preads_fofn_plf },
-                                    outputs = {"pdb_build_done": pdb_build_done,
-                                               "preads_db": preads_db,
-                                               "run_jobs": run_jobs,
+    make_build_pdb_task  = PypeTask(inputs = {'preads_fofn': preads_fofn_plf },
+                                    outputs = {'pdb_build_done': pdb_build_done,
+                                               'preads_db': preads_db,
+                                               'run_jobs': run_jobs,
                                     },
                                     parameters = parameters,
                                     TaskType = MyFakePypeThreadTaskBase,
-                                    URL = "task://localhost/build_pdb")
+                                    URL = 'task://localhost/build_pdb')
     build_pdb_task = make_build_pdb_task(pype_tasks.task_build_pdb)
 
     wf.addTasks([build_pdb_task])
@@ -345,7 +345,7 @@ def run(wf, config,
 
     preads_nblock = support.get_nblock(fn(preads_db))
     #### run daligner
-    config["sge_option_da"] = config["sge_option_pda"]
+    config['sge_option_da'] = config['sge_option_pda']
 
     scattered_plf = os.path.join(pread_dir, 'daligner-scatter', 'scattered.json')
     make_daligner_scatter = PypeTask(
@@ -374,20 +374,20 @@ def run(wf, config,
 
     p_gathered_las_plf = makePypeLocalFile(os.path.join(pread_dir, 'gathered-las', 'gathered-las.txt'))
     parameters =  {
-            "nblock": preads_nblock,
+            'nblock': preads_nblock,
     }
     make_daligner_gather = PypeTask(
                 inputs = daligner_out,
-                outputs =  {"gathered": p_gathered_las_plf},
+                outputs =  {'gathered': p_gathered_las_plf},
                 parameters = parameters,
                 TaskType = MyFakePypeThreadTaskBase,
-                URL = "task://localhost/pda_check" )
+                URL = 'task://localhost/pda_check' )
     check_p_da_task = make_daligner_gather(pype_tasks.task_daligner_gather)
     wf.addTask(check_p_da_task)
     wf.refreshTargets(exitOnFailure=exitOnFailure)
 
     # Merge .las files.
-    config["sge_option_la"] = config["sge_option_pla"]
+    config['sge_option_la'] = config['sge_option_pla']
     scattered_plf = os.path.join(pread_dir, 'merge-scatter', 'scattered.json')
     make_task = PypeTask(
             inputs = {
@@ -411,15 +411,15 @@ def run(wf, config,
     merge_tasks, merge_out, _ = create_merge_tasks(pread_dir, scattered_plf)
     wf.addTasks(merge_tasks)
 
-    p_merge_done = makePypeLocalFile(os.path.join( pread_dir, 'preads-merge', 'p_merge_done'))
+    p_merge_gathered = makePypeLocalFile(os.path.join(pread_dir, 'preads-merge', 'p_merge_gathered'))
 
-    make_check_p_merge_task = PypeTask( inputs = merge_out,
-               outputs =  {"p_merge_done": p_merge_done},
+    make_task = PypeTask( inputs = merge_out,
+               outputs =  {'p_merge_gathered': p_merge_gathered},
                TaskType = MyFakePypeThreadTaskBase,
-               URL = "task://localhost/pmerge_check" )
-    wf.addTask(make_check_p_merge_task(pype_tasks.check_p_merge_check_task))
+               URL = 'task://localhost/pmerge_gather' )
+    wf.addTask(make_task(pype_tasks.task_p_merge_gather))
 
-    concurrent_jobs = config["ovlp_concurrent_jobs"]
+    concurrent_jobs = config['ovlp_concurrent_jobs']
     setNumThreadAllowed(concurrent_jobs, concurrent_jobs)
 
     wf.refreshTargets(exitOnFailure=exitOnFailure)
@@ -429,33 +429,33 @@ def run(wf, config,
     db2falcon_done = makePypeLocalFile(os.path.join(db2falcon_dir, 'db2falcon_done'))
     preads4falcon_plf = makePypeLocalFile(os.path.join(db2falcon_dir, 'preads4falcon.fasta'))
     make_run_db2falcon = PypeTask(
-               inputs = {"p_merge_done": p_merge_done,
-                         "preads_db": preads_db,
+               inputs = {'p_merge_gathered': p_merge_gathered,
+                         'preads_db': preads_db,
                         },
-               outputs =  {"db2falcon_done": db2falcon_done,
-                           "preads4falcon": preads4falcon_plf,
+               outputs =  {'db2falcon_done': db2falcon_done,
+                           'preads4falcon': preads4falcon_plf,
                           },
-               parameters = {"wd": db2falcon_dir,
-                             "config": config,
-                             "sge_option": config["sge_option_fc"],
+               parameters = {'wd': db2falcon_dir,
+                             'config': config,
+                             'sge_option': config['sge_option_fc'],
                             },
                TaskType = MyFakePypeThreadTaskBase,
-               URL = "task://localhost/db2falcon" )
+               URL = 'task://localhost/db2falcon' )
     wf.addTask(make_run_db2falcon(pype_tasks.task_run_db2falcon))
 
     falcon_asm_done = makePypeLocalFile( os.path.join(falcon_asm_dir, 'falcon_asm_done'))
     make_run_falcon_asm = PypeTask(
-               inputs = {"db2falcon_done": db2falcon_done, "db_file": preads_db,
-                         "preads4falcon": preads4falcon_plf,
+               inputs = {'db2falcon_done': db2falcon_done, 'db_file': preads_db,
+                         'preads4falcon': preads4falcon_plf,
                         },
-               outputs =  {"falcon_asm_done": falcon_asm_done},
-               parameters = {"wd": falcon_asm_dir,
-                             "config": config,
-                             "pread_dir": pread_dir,
-                             "sge_option": config["sge_option_fc"],
+               outputs =  {'falcon_asm_done': falcon_asm_done},
+               parameters = {'wd': falcon_asm_dir,
+                             'config': config,
+                             'pread_dir': pread_dir,
+                             'sge_option': config['sge_option_fc'],
                },
                TaskType = MyFakePypeThreadTaskBase,
-               URL = "task://localhost/falcon_asm" )
+               URL = 'task://localhost/falcon_asm' )
     wf.addTask(make_run_falcon_asm(pype_tasks.task_run_falcon_asm))
     wf.refreshTargets()
 

--- a/falcon_kit/pype_tasks.py
+++ b/falcon_kit/pype_tasks.py
@@ -1,7 +1,9 @@
 # PypeTask functions now need to be module-level.
 from . import run_support as support
+from . import bash # for scattering
 from pypeflow.simple_pwatcher_bridge import fn # not really needed
 import collections
+import json
 import logging
 import os.path
 LOG = logging.getLogger(__name__)
@@ -128,7 +130,6 @@ def task_run_falcon_asm(self):
     self.generated_script_fn = script_fn
 
 def task_report_pre_assembly(self):
-    # TODO(CD): Bashify this, in case it is slow.
     i_raw_reads_db_fn = fn(self.raw_reads_db)
     i_preads_fofn_fn = fn(self.preads_fofn)
     i_length_cutoff_fn = fn(self.length_cutoff_fn)
@@ -161,11 +162,11 @@ def task_run_daligner(self):
     daligner_script = self.parameters["daligner_script"]
     job_uid = self.parameters["job_uid"]
     cwd = self.parameters["cwd"]
-    mkdir(cwd)
+    #mkdir(cwd)
     db_prefix = self.parameters["db_prefix"]
     config = self.parameters["config"]
     script_dir = os.path.join(cwd)
-    script_fn =  os.path.join(script_dir , "rj_%s.sh" % (job_uid))
+    script_fn = os.path.join(script_dir , "rj_%s.sh" % (job_uid))
     args = {
         'daligner_script': daligner_script,
         'db_prefix': db_prefix,
@@ -190,6 +191,7 @@ def read_gathered_las(path):
     return result
 
 def task_run_las_merge(self):
+    job_done = fn(self.job_done)
     gathered_las_fn = fn(self.gathered_las)
     script = self.parameters["merge_script"]
     job_id = self.parameters["job_id"] # aka "block"
@@ -204,7 +206,6 @@ def task_run_las_merge(self):
         LOG.debug('symlink {!r} -> {!r}'.format(src, tgt))
         os.symlink(src, tgt)
 
-    job_done = fn(self.job_done)
     config = self.parameters["config"]
 
     script_dir = os.path.join( cwd )
@@ -226,11 +227,12 @@ def task_run_consensus(self):
     cwd = self.parameters["cwd"]
     config = self.parameters["config"]
     prefix = self.parameters["prefix"]
+    p_id = int(job_id)
     script_dir = os.path.join( cwd )
-    script_fn =  os.path.join( script_dir , "c_%05d.sh" % (job_id))
-    db_fn = os.path.abspath('{cwd}/../../{prefix}'.format(**locals())) # ASSUMING 2-levels deep
+    script_fn =  os.path.join( script_dir , "c_%05d.sh" % (p_id))
+    db_fn = os.path.abspath('{cwd}/../../{prefix}'.format(**locals())) # ASSUMING 2-levels deep. TODO: DB should be an input.
     merge_job_dir = os.path.dirname(merge_job_done)
-    # by convention, we assume the name of the .las file
+    # by convention, we assume the name of the .las file #TODO: That should be an output of task_run_merge.
     las_fn = os.path.abspath('{merge_job_dir}/{prefix}.{job_id}.las'.format(**locals()))
     args = {
         'db_fn': db_fn,
@@ -243,6 +245,123 @@ def task_run_consensus(self):
     support.run_consensus(**args)
     self.generated_script_fn = script_fn
 
+def task_daligner_scatter(self):
+    run_jobs_fn = self.run_jobs_fn
+    db_build_done = self.db_build_done
+    scatter_fn = self.scatter_fn
+    par = self.parameters
+    db_prefix = par['db_prefix']
+    nblock = par['nblock']
+    config = par['config']
+    pread_aln = par['pread_aln'] # False  for raw_reads
+    skip_checks = config.get('skip_checks')
+    tasks = []
+    LOG.info('Skip LAcheck after daligner? {}'.format(skip_checks))
+    func = task_run_daligner
+    func_name = '{}.{}'.format(func.__module__, func.__name__)
+    for job_uid, script in bash.scripts_daligner(run_jobs_fn, db_prefix, db_build_done, nblock, pread_aln, skip_checks):
+        job_done_fn = 'job_%s_done' %job_uid
+        parameters =  {"daligner_script": script,
+                       "job_uid": job_uid,
+                       "config": config,
+                       "sge_option": config["sge_option_da"],
+                       "db_prefix": db_prefix}
+        inputs = {"db_build_done": db_build_done}
+        outputs = {"job_done": job_done_fn}
+        python_function = func_name,
+        URL = "task://localhost/d_%s_%s" %(job_uid, db_prefix)
+        daligner_task = {
+                'inputs': inputs,
+                'outputs': outputs,
+                'parameters': parameters,
+                'python_function': python_function,
+                'URL': URL,
+        }
+        tasks.append(daligner_task)
+    content = json.dumps(tasks, sort_keys=True, indent=4, separators=(',', ': '))
+    open(scatter_fn, 'w').write(content)
+
+def task_merge_scatter(self):
+    run_jobs_fn = self.run_jobs
+    gathered_las_fn = self.gathered_las
+    scatter_fn = self.scattered
+    par = self.parameters
+    db_prefix = par['db_prefix']
+    config = par['config']
+    func = task_run_las_merge
+    func_name = '{}.{}'.format(func.__module__, func.__name__)
+
+    merge_scripts = bash.scripts_merge(config, db_prefix, run_jobs_fn)
+    tasks = []
+    for p_id, merge_script in merge_scripts:
+        parameters =  {"merge_script": merge_script,
+                       "job_id": p_id,
+                       "config": config,
+                       "sge_option": config["sge_option_la"],
+                      }
+        job_done_fn = 'm_%05d_done' % p_id
+        inputs = {"gathered_las": gathered_las_fn}
+        outputs = {"job_done": job_done_fn}
+        python_function = func_name,
+        URL = "task://localhost/m_%05d_%s" %(p_id, db_prefix)
+        task_desc = {
+                'inputs': inputs,
+                'outputs': outputs,
+                'parameters': parameters,
+                'python_function': python_function,
+                'URL': URL,
+        }
+        tasks.append(task_desc)
+
+    content = json.dumps(tasks, sort_keys=True, indent=4, separators=(',', ': '))
+    open(scatter_fn, 'w').write(content)
+def task_consensus_scatter(self):
+    #p_ids_merge_job_done = self.p_ids_merge_job_done
+    scatter_fn = self.scattered
+    wd = os.path.dirname(scatter_fn)
+    par = self.parameters
+    db_prefix = par['db_prefix']
+    config = par['config']
+
+    func = task_run_consensus
+    func_name = '{}.{}'.format(func.__module__, func.__name__)
+    basedir = os.path.dirname(wd) # by convention, since we want to preseve some old paths for now
+
+    tasks = []
+    for p_id, job_done in self.inputs.iteritems(): #p_ids_merge_job_done:
+        cns_label = 'cns_%05d' %int(p_id)
+        #rdir = os.path.join(basedir, 'preads', cns_label)
+        #out_done_fn = os.path.abspath('%s/%s_done' % (rdir, cns_label))
+        #out_file_fn = os.path.abspath('%s/%s.fasta' % (rdir, cns_label))
+        out_done_fn = '%s_done' % cns_label
+        out_file_fn = '%s.fasta' % cns_label
+
+        parameters =  {#'cwd': rdir,
+                       'job_id': p_id,
+                       'prefix': db_prefix,
+                       'config': config,
+                       'sge_option': config['sge_option_cns'],
+        }
+        inputs =  {'job_done': job_done,
+        }
+        outputs = {'out_file': out_file_fn,
+                   'out_done': out_done_fn,
+        }
+        python_function = func_name,
+        URL = 'task://localhost/%s' %cns_label
+        task_desc = {
+                'inputs': inputs,
+                'outputs': outputs,
+                'parameters': parameters,
+                'python_function': python_function,
+                'URL': URL,
+        }
+        tasks.append(task_desc)
+        #consensus_out["cjob_%d" % p_id] = out_done
+        #consensus_out["cjob_%d" % p_id] = out_file
+    content = json.dumps(tasks, sort_keys=True, indent=4, separators=(',', ': '))
+    open(scatter_fn, 'w').write(content)
+
 def task_daligner_gather(self):
     """Find all .las leaves so far.
     """
@@ -252,31 +371,31 @@ def task_daligner_gather(self):
     LOG.debug('nblock=%d, out_dir:\n%s'%(nblock, out_dict))
     job_rundirs = [os.path.dirname(fn(dal_done)) for dal_done in out_dict.values()]
     wdir = os.path.dirname(gathered_fn)
-    mkdir(wdir)
+    #mkdir(wdir)
     with open(gathered_fn, 'w') as ofs:
         for block, las_path in support.daligner_gather_las(job_rundirs):
             ofs.write('{} {}\n'.format(block, las_path))
 
     # Because we need a script always, for now.
-    script_fn = os.path.join(wdir, 'noop.sh')
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
+    #script_fn = os.path.join(wdir, 'noop.sh')
+    #open(script_fn, 'w').write('echo NOOP raw')
+    #self.generated_script_fn = script_fn
 
-def check_r_cns_task(self):
+def task_cns_gather(self):
     with open(fn(self.preads_fofn),  "w") as f:
         for fa_fn in sorted(fn(plf) for plf in self.inputs.values()):
             print >>f, fa_fn
     wdir = os.path.dirname(fn(self.cns_done))
-    #mkdir(wdir) We SHOULD need this! TODO
+    #mkdir(wdir)
     system("touch %s" % fn(self.cns_done))
-    script_fn = os.path.join(wdir, 'noop.sh')
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
+    #script_fn = os.path.join(wdir, 'noop.sh')
+    #open(script_fn, 'w').write('echo NOOP raw')
+    #self.generated_script_fn = script_fn
 
 def check_p_merge_check_task(self):
     wdir = os.path.dirname(fn(self.p_merge_done))
     mkdir(wdir)
     system("touch %s" % fn(self.p_merge_done))
-    script_fn = os.path.join(wdir, 'noop.sh')
-    open(script_fn, 'w').write('echo NOOP raw')
-    self.generated_script_fn = script_fn
+    #script_fn = os.path.join(wdir, 'noop.sh')
+    #open(script_fn, 'w').write('echo NOOP raw')
+    #self.generated_script_fn = script_fn

--- a/falcon_kit/pype_tasks.py
+++ b/falcon_kit/pype_tasks.py
@@ -1,0 +1,282 @@
+# PypeTask functions now need to be module-level.
+from . import run_support as support
+from pypeflow.simple_pwatcher_bridge import fn # not really needed
+import collections
+import logging
+import os.path
+LOG = logging.getLogger(__name__)
+
+def system(call, check=False):
+    LOG.debug('$(%s)' %repr(call))
+    rc = os.system(call)
+    msg = "Call %r returned %d." % (call, rc)
+    if rc:
+        LOG.warning(msg)
+        if check:
+            raise Exception(msg)
+    else:
+        LOG.debug(msg)
+    return rc
+
+def remove(*fns):
+    for fn in fns:
+        if os.path.exists(fn):
+            os.remove(fn)
+        assert not os.path.exists(fn)
+
+# Someday, we can drop mkdir() in these.
+def mkdir(d):
+    if not os.path.isdir(d):
+        os.makedirs(d)
+
+def task_make_fofn_abs_raw(self):
+    script_fn = 'noop.sh'
+    open(script_fn, 'w').write('echo NOOP raw')
+    self.generated_script_fn = script_fn
+    mkdir(os.path.dirname(fn(self.o_fofn)))
+    support.make_fofn_abs(fn(self.i_fofn), fn(self.o_fofn))
+
+def task_make_fofn_abs_preads(self):
+    script_fn = 'noop.sh'
+    open(script_fn, 'w').write('echo NOOP preads')
+    self.generated_script_fn = script_fn
+    mkdir(os.path.dirname(fn(self.o_fofn)))
+    support.make_fofn_abs(fn(self.i_fofn), fn(self.o_fofn))
+
+def task_build_rdb(self):
+    input_fofn_fn = fn(self.input_fofn)
+    job_done = fn(self.rdb_build_done)
+    db = fn(self.raw_reads_db)
+    run_jobs = fn(self.run_jobs)
+    remove(job_done, db, run_jobs)
+    work_dir = self.parameters["work_dir"]
+    config = self.parameters["config"]
+
+    script_fn = os.path.join( work_dir, "prepare_rdb.sh" )
+    args = {
+        'input_fofn_fn': input_fofn_fn,
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+        'run_jobs_fn': run_jobs,
+    }
+    support.build_rdb(**args)
+    self.generated_script_fn = script_fn
+
+def task_build_pdb(self):  #essential the same as build_rdb() but the subtle differences are tricky to consolidate to one function
+    input_fofn_fn = fn(self.preads_fofn)
+    job_done = fn(self.pdb_build_done)
+    db = fn(self.preads_db)
+    run_jobs = fn(self.run_jobs)
+    remove(job_done, db, run_jobs)
+    work_dir = self.parameters["work_dir"]
+    config = self.parameters["config"]
+
+    script_fn = os.path.join( work_dir, "prepare_pdb.sh" )
+    args = {
+        'input_fofn_fn': input_fofn_fn,
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+        'run_jobs_fn': run_jobs,
+    }
+    support.build_pdb(**args)
+    self.generated_script_fn = script_fn
+
+def task_run_db2falcon(self):
+    wd = self.parameters["wd"]
+    mkdir(wd)
+    #self.p_merge_done
+    job_done = fn(self.db2falcon_done)
+    preads4falcon_fn = fn(self.preads4falcon)
+    preads_db = fn(self.preads_db)
+    config = self.parameters["config"]
+    script_dir = os.path.join(wd)
+    script_fn = os.path.join(script_dir ,"run_db2falcon.sh")
+    args = {
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+        'preads4falcon_fn': preads4falcon_fn,
+        'preads_db': preads_db,
+    }
+    support.run_db2falcon(**args)
+    self.generated_script_fn = script_fn
+
+def task_run_falcon_asm(self):
+    wd = self.parameters["wd"]
+    #self.db2falcon_done
+    db_file = fn(self.db_file)
+    job_done = fn(self.falcon_asm_done)
+    config = self.parameters["config"]
+    pread_dir = self.parameters["pread_dir"]
+    preads4falcon_fn = fn(self.preads4falcon)
+    script_dir = os.path.join( wd )
+    script_fn =  os.path.join( script_dir ,"run_falcon_asm.sh" )
+    # Generate las.fofn in run-dir.
+    system('cd {}; find {}/m_*/ -name "preads.*.las" >| las.fofn'.format(wd, pread_dir))
+    las_fofn_fn = 'las.fofn'
+    args = {
+        'las_fofn_fn': las_fofn_fn,
+        'preads4falcon_fasta_fn': preads4falcon_fn,
+        'db_file_fn': db_file,
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+    }
+    support.run_falcon_asm(**args)
+    self.generated_script_fn = script_fn
+
+def task_report_pre_assembly(self):
+    # TODO(CD): Bashify this, in case it is slow.
+    i_raw_reads_db_fn = fn(self.raw_reads_db)
+    i_preads_fofn_fn = fn(self.preads_fofn)
+    i_length_cutoff_fn = fn(self.length_cutoff_fn)
+    o_json_fn = fn(self.pre_assembly_report)
+    cfg = self.parameters
+    genome_length = int(cfg.get('genome_size', 0)) # different name in falcon
+    length_cutoff = int(cfg['length_cutoff'])
+    # Update length_cutoff if auto-calc (when length_cutoff is negative).
+    # i_length_cutoff_fn was created long ago, so no filesystem issues.
+    length_cutoff = support.get_length_cutoff(length_cutoff, i_length_cutoff_fn)
+    cwd = self.parameters['cwd']
+    mkdir(cwd)
+    script_fn = os.path.join(cwd , 'run_report_pre_assembly.sh')
+    job_done = os.path.join(cwd, 'report_pa_done')
+    kwds = {
+        'i_raw_reads_db_fn': i_raw_reads_db_fn,
+        'i_preads_fofn_fn': i_preads_fofn_fn,
+        'genome_length': genome_length,
+        'length_cutoff': length_cutoff,
+        'o_json_fn': o_json_fn,
+        'job_done': job_done,
+        'script_fn': script_fn,
+    }
+    LOG.info('Report inputs: {}'.format(repr(kwds)))
+    support.run_report_pre_assembly(**kwds)
+    self.generated_script_fn = script_fn
+
+def task_run_daligner(self):
+    job_done = fn(self.job_done)
+    daligner_script = self.parameters["daligner_script"]
+    job_uid = self.parameters["job_uid"]
+    cwd = self.parameters["cwd"]
+    mkdir(cwd)
+    db_prefix = self.parameters["db_prefix"]
+    config = self.parameters["config"]
+    script_dir = os.path.join(cwd)
+    script_fn =  os.path.join(script_dir , "rj_%s.sh" % (job_uid))
+    args = {
+        'daligner_script': daligner_script,
+        'db_prefix': db_prefix,
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+    }
+    support.run_daligner(**args)
+    self.generated_script_fn = script_fn
+
+def read_gathered_las(path):
+    """Return dict of block->[las_paths].
+    For now, these are ws separated on each line of input.
+    """
+    result = collections.defaultdict(list)
+    with open(path) as ifs:
+        for line in ifs:
+            block, las_path = line.split()
+            result[int(block)].append(las_path)
+    #LOG.warning('path={!r}, result={}'.format(
+    #    path, pprint.pformat(result)))
+    return result
+
+def task_run_las_merge(self):
+    gathered_las_fn = fn(self.gathered_las)
+    script = self.parameters["merge_script"]
+    job_id = self.parameters["job_id"] # aka "block"
+    cwd = self.parameters["cwd"]
+    mkdir(cwd)
+
+    gathered_dict = read_gathered_las(gathered_las_fn)
+    las_paths = gathered_dict[job_id]
+    for las_path in las_paths:
+        src = os.path.relpath(las_path, cwd)
+        tgt = os.path.join(cwd, os.path.basename(las_path))
+        LOG.debug('symlink {!r} -> {!r}'.format(src, tgt))
+        os.symlink(src, tgt)
+
+    job_done = fn(self.job_done)
+    config = self.parameters["config"]
+
+    script_dir = os.path.join( cwd )
+    script_fn =  os.path.join( script_dir , "rp_%05d.sh" % (job_id))
+    args = {
+        'script': script,
+        'config': config,
+        'job_done': job_done,
+        'script_fn': script_fn,
+    }
+    support.run_las_merge(**args)
+    self.generated_script_fn = script_fn
+
+def task_run_consensus(self):
+    merge_job_done = fn(self.job_done)
+    out_file_fn = fn(self.out_file)
+    out_done = fn(self.out_done)
+    job_id = self.parameters["job_id"]
+    cwd = self.parameters["cwd"]
+    config = self.parameters["config"]
+    prefix = self.parameters["prefix"]
+    script_dir = os.path.join( cwd )
+    script_fn =  os.path.join( script_dir , "c_%05d.sh" % (job_id))
+    db_fn = os.path.abspath('{cwd}/../../{prefix}'.format(**locals())) # ASSUMING 2-levels deep
+    merge_job_dir = os.path.dirname(merge_job_done)
+    # by convention, we assume the name of the .las file
+    las_fn = os.path.abspath('{merge_job_dir}/{prefix}.{job_id}.las'.format(**locals()))
+    args = {
+        'db_fn': db_fn,
+        'las_fn': las_fn,
+        'out_file_fn': out_file_fn,
+        'config': config,
+        'job_done': out_done,
+        'script_fn': script_fn,
+    }
+    support.run_consensus(**args)
+    self.generated_script_fn = script_fn
+
+def task_daligner_gather(self):
+    """Find all .las leaves so far.
+    """
+    out_dict = self.inputs
+    gathered_fn = fn(self.gathered)
+    nblock = self.parameters['nblock']
+    LOG.debug('nblock=%d, out_dir:\n%s'%(nblock, out_dict))
+    job_rundirs = [os.path.dirname(fn(dal_done)) for dal_done in out_dict.values()]
+    wdir = os.path.dirname(gathered_fn)
+    mkdir(wdir)
+    with open(gathered_fn, 'w') as ofs:
+        for block, las_path in support.daligner_gather_las(job_rundirs):
+            ofs.write('{} {}\n'.format(block, las_path))
+
+    # Because we need a script always, for now.
+    script_fn = os.path.join(wdir, 'noop.sh')
+    open(script_fn, 'w').write('echo NOOP raw')
+    self.generated_script_fn = script_fn
+
+def check_r_cns_task(self):
+    with open(fn(self.preads_fofn),  "w") as f:
+        for fa_fn in sorted(fn(plf) for plf in self.inputs.values()):
+            print >>f, fa_fn
+    wdir = os.path.dirname(fn(self.cns_done))
+    #mkdir(wdir) We SHOULD need this! TODO
+    system("touch %s" % fn(self.cns_done))
+    script_fn = os.path.join(wdir, 'noop.sh')
+    open(script_fn, 'w').write('echo NOOP raw')
+    self.generated_script_fn = script_fn
+
+def check_p_merge_check_task(self):
+    wdir = os.path.dirname(fn(self.p_merge_done))
+    mkdir(wdir)
+    system("touch %s" % fn(self.p_merge_done))
+    script_fn = os.path.join(wdir, 'noop.sh')
+    open(script_fn, 'w').write('echo NOOP raw')
+    self.generated_script_fn = script_fn

--- a/falcon_kit/pype_tasks.py
+++ b/falcon_kit/pype_tasks.py
@@ -11,7 +11,7 @@ LOG = logging.getLogger(__name__)
 def system(call, check=False):
     LOG.debug('$(%s)' %repr(call))
     rc = os.system(call)
-    msg = "Call %r returned %d." % (call, rc)
+    msg = 'Call %r returned %d.' % (call, rc)
     if rc:
         LOG.warning(msg)
         if check:
@@ -51,10 +51,10 @@ def task_build_rdb(self):
     db = fn(self.raw_reads_db)
     run_jobs = fn(self.run_jobs)
     remove(job_done, db, run_jobs)
-    work_dir = self.parameters["work_dir"]
-    config = self.parameters["config"]
+    work_dir = self.parameters['work_dir']
+    config = self.parameters['config']
 
-    script_fn = os.path.join( work_dir, "prepare_rdb.sh" )
+    script_fn = os.path.join( work_dir, 'prepare_rdb.sh' )
     args = {
         'input_fofn_fn': input_fofn_fn,
         'config': config,
@@ -71,10 +71,10 @@ def task_build_pdb(self):  #essential the same as build_rdb() but the subtle dif
     db = fn(self.preads_db)
     run_jobs = fn(self.run_jobs)
     remove(job_done, db, run_jobs)
-    work_dir = self.parameters["work_dir"]
-    config = self.parameters["config"]
+    work_dir = self.parameters['work_dir']
+    config = self.parameters['config']
 
-    script_fn = os.path.join( work_dir, "prepare_pdb.sh" )
+    script_fn = os.path.join( work_dir, 'prepare_pdb.sh' )
     args = {
         'input_fofn_fn': input_fofn_fn,
         'config': config,
@@ -86,15 +86,15 @@ def task_build_pdb(self):  #essential the same as build_rdb() but the subtle dif
     self.generated_script_fn = script_fn
 
 def task_run_db2falcon(self):
-    wd = self.parameters["wd"]
+    wd = self.parameters['wd']
     mkdir(wd)
-    #self.p_merge_done
+    #self.p_merge_gathered
     job_done = fn(self.db2falcon_done)
     preads4falcon_fn = fn(self.preads4falcon)
     preads_db = fn(self.preads_db)
-    config = self.parameters["config"]
+    config = self.parameters['config']
     script_dir = os.path.join(wd)
-    script_fn = os.path.join(script_dir ,"run_db2falcon.sh")
+    script_fn = os.path.join(script_dir ,'run_db2falcon.sh')
     args = {
         'config': config,
         'job_done': job_done,
@@ -106,15 +106,15 @@ def task_run_db2falcon(self):
     self.generated_script_fn = script_fn
 
 def task_run_falcon_asm(self):
-    wd = self.parameters["wd"]
+    wd = self.parameters['wd']
     #self.db2falcon_done
     db_file = fn(self.db_file)
     job_done = fn(self.falcon_asm_done)
-    config = self.parameters["config"]
-    pread_dir = self.parameters["pread_dir"]
+    config = self.parameters['config']
+    pread_dir = self.parameters['pread_dir']
     preads4falcon_fn = fn(self.preads4falcon)
     script_dir = os.path.join( wd )
-    script_fn =  os.path.join( script_dir ,"run_falcon_asm.sh" )
+    script_fn =  os.path.join( script_dir ,'run_falcon_asm.sh' )
     # Generate las.fofn in run-dir.
     system('cd {}; find {}/m_*/ -name "preads.*.las" >| las.fofn'.format(wd, pread_dir))
     las_fofn_fn = 'las.fofn'
@@ -159,14 +159,14 @@ def task_report_pre_assembly(self):
 
 def task_run_daligner(self):
     job_done = fn(self.job_done)
-    daligner_script = self.parameters["daligner_script"]
-    job_uid = self.parameters["job_uid"]
-    cwd = self.parameters["cwd"]
+    daligner_script = self.parameters['daligner_script']
+    job_uid = self.parameters['job_uid']
+    cwd = self.parameters['cwd']
     #mkdir(cwd)
-    db_prefix = self.parameters["db_prefix"]
-    config = self.parameters["config"]
+    db_prefix = self.parameters['db_prefix']
+    config = self.parameters['config']
     script_dir = os.path.join(cwd)
-    script_fn = os.path.join(script_dir , "rj_%s.sh" % (job_uid))
+    script_fn = os.path.join(script_dir , 'rj_%s.sh' % (job_uid))
     args = {
         'daligner_script': daligner_script,
         'db_prefix': db_prefix,
@@ -193,9 +193,9 @@ def read_gathered_las(path):
 def task_run_las_merge(self):
     job_done = fn(self.job_done)
     gathered_las_fn = fn(self.gathered_las)
-    script = self.parameters["merge_script"]
-    job_id = self.parameters["job_id"] # aka "block"
-    cwd = self.parameters["cwd"]
+    script = self.parameters['merge_script']
+    job_id = self.parameters['job_id'] # aka 'block'
+    cwd = self.parameters['cwd']
     mkdir(cwd)
 
     gathered_dict = read_gathered_las(gathered_las_fn)
@@ -206,10 +206,10 @@ def task_run_las_merge(self):
         LOG.debug('symlink {!r} -> {!r}'.format(src, tgt))
         os.symlink(src, tgt)
 
-    config = self.parameters["config"]
+    config = self.parameters['config']
 
     script_dir = os.path.join( cwd )
-    script_fn =  os.path.join( script_dir , "rp_%05d.sh" % (job_id))
+    script_fn =  os.path.join( script_dir , 'rp_%05d.sh' % (job_id))
     args = {
         'script': script,
         'config': config,
@@ -223,13 +223,13 @@ def task_run_consensus(self):
     merge_job_done = fn(self.job_done)
     out_file_fn = fn(self.out_file)
     out_done = fn(self.out_done)
-    job_id = self.parameters["job_id"]
-    cwd = self.parameters["cwd"]
-    config = self.parameters["config"]
-    prefix = self.parameters["prefix"]
+    job_id = self.parameters['job_id']
+    cwd = self.parameters['cwd']
+    config = self.parameters['config']
+    prefix = self.parameters['prefix']
     p_id = int(job_id)
     script_dir = os.path.join( cwd )
-    script_fn =  os.path.join( script_dir , "c_%05d.sh" % (p_id))
+    script_fn =  os.path.join( script_dir , 'c_%05d.sh' % (p_id))
     db_fn = os.path.abspath('{cwd}/../../{prefix}'.format(**locals())) # ASSUMING 2-levels deep. TODO: DB should be an input.
     merge_job_dir = os.path.dirname(merge_job_done)
     # by convention, we assume the name of the .las file #TODO: That should be an output of task_run_merge.
@@ -261,15 +261,15 @@ def task_daligner_scatter(self):
     func_name = '{}.{}'.format(func.__module__, func.__name__)
     for job_uid, script in bash.scripts_daligner(run_jobs_fn, db_prefix, db_build_done, nblock, pread_aln, skip_checks):
         job_done_fn = 'job_%s_done' %job_uid
-        parameters =  {"daligner_script": script,
-                       "job_uid": job_uid,
-                       "config": config,
-                       "sge_option": config["sge_option_da"],
-                       "db_prefix": db_prefix}
-        inputs = {"db_build_done": db_build_done}
-        outputs = {"job_done": job_done_fn}
+        parameters =  {'daligner_script': script,
+                       'job_uid': job_uid,
+                       'config': config,
+                       'sge_option': config['sge_option_da'],
+                       'db_prefix': db_prefix}
+        inputs = {'db_build_done': db_build_done}
+        outputs = {'job_done': job_done_fn}
         python_function = func_name,
-        URL = "task://localhost/d_%s_%s" %(job_uid, db_prefix)
+        URL = 'task://localhost/d_%s_%s' %(job_uid, db_prefix)
         daligner_task = {
                 'inputs': inputs,
                 'outputs': outputs,
@@ -294,16 +294,16 @@ def task_merge_scatter(self):
     merge_scripts = bash.scripts_merge(config, db_prefix, run_jobs_fn)
     tasks = []
     for p_id, merge_script in merge_scripts:
-        parameters =  {"merge_script": merge_script,
-                       "job_id": p_id,
-                       "config": config,
-                       "sge_option": config["sge_option_la"],
+        parameters =  {'merge_script': merge_script,
+                       'job_id': p_id,
+                       'config': config,
+                       'sge_option': config['sge_option_la'],
                       }
         job_done_fn = 'm_%05d_done' % p_id
-        inputs = {"gathered_las": gathered_las_fn}
-        outputs = {"job_done": job_done_fn}
+        inputs = {'gathered_las': gathered_las_fn}
+        outputs = {'job_done': job_done_fn}
         python_function = func_name,
-        URL = "task://localhost/m_%05d_%s" %(p_id, db_prefix)
+        URL = 'task://localhost/m_%05d_%s' %(p_id, db_prefix)
         task_desc = {
                 'inputs': inputs,
                 'outputs': outputs,
@@ -357,8 +357,8 @@ def task_consensus_scatter(self):
                 'URL': URL,
         }
         tasks.append(task_desc)
-        #consensus_out["cjob_%d" % p_id] = out_done
-        #consensus_out["cjob_%d" % p_id] = out_file
+        #consensus_out['cjob_%d' % p_id] = out_done
+        #consensus_out['cjob_%d' % p_id] = out_file
     content = json.dumps(tasks, sort_keys=True, indent=4, separators=(',', ': '))
     open(scatter_fn, 'w').write(content)
 
@@ -382,20 +382,20 @@ def task_daligner_gather(self):
     #self.generated_script_fn = script_fn
 
 def task_cns_gather(self):
-    with open(fn(self.preads_fofn),  "w") as f:
+    with open(fn(self.preads_fofn),  'w') as f:
         for fa_fn in sorted(fn(plf) for plf in self.inputs.values()):
             print >>f, fa_fn
     wdir = os.path.dirname(fn(self.cns_done))
     #mkdir(wdir)
-    system("touch %s" % fn(self.cns_done))
+    system('touch %s' % fn(self.cns_done))
     #script_fn = os.path.join(wdir, 'noop.sh')
     #open(script_fn, 'w').write('echo NOOP raw')
     #self.generated_script_fn = script_fn
 
-def check_p_merge_check_task(self):
-    wdir = os.path.dirname(fn(self.p_merge_done))
+def task_p_merge_gather(self):
+    wdir = os.path.dirname(fn(self.p_merge_gathered))
     mkdir(wdir)
-    system("touch %s" % fn(self.p_merge_done))
+    system('touch %s' % fn(self.p_merge_gathered))
     #script_fn = os.path.join(wdir, 'noop.sh')
     #open(script_fn, 'w').write('echo NOOP raw')
     #self.generated_script_fn = script_fn


### PR DESCRIPTION
Jason, Don't worry. I'm being careful. Most of this was done last week, so it's pretty well tested. I'm just rebasing here. Multiple goals:

* Have separate tasks for scattering and gathering, to correspond better with how pbsmrtpipe works.
* Provide well-defined, deterministic outputs for each task (instead of searching a bunch of directories to infer outputs).
  * E.g. we used to search all `m_*` directories for `preads.*.las`
* Move tasks into their own module, so `do_task.py` can run them without importing `run1.py`.
* Use single-quotes more consistently.
  * Unlike in Perl, single and double quotes in Python have no semantic difference. But consistency helps visually.
  * I have also taken this opportunity to remove a lot of whitespace, to conform better with PEP8.
* Rename more directories.
  * I try to avoid this, but we need some consistency. This might require a user to re-create daligner runs, but a fresh start should be fine.

SAT-434