### PR TITLE
too many arguments for format string

### DIFF
--- a/src/c/DW_banded.c
+++ b/src/c/DW_banded.c
@@ -105,7 +105,7 @@ void* my_calloc(int nitems, size_t size, char const* msg, int lineno) {
     }
     void* result = calloc((size_t)nitems, size);
     if (NULL == result) {
-        fprintf(stderr, "CRITICAL ERROR: %s=calloc(%d, %zu) returned 0.\n",
+        fprintf(stderr, "CRITICAL ERROR: %s=calloc(%d, %zu, ..., %d) returned 0.\n",
                 msg, nitems, size, lineno);
         abort();
     }


### PR DESCRIPTION
Spotted via the compiler warnings trying to build FALCON locally,

```
src/c/DW_banded.c: In function ‘my_calloc’:
src/c/DW_banded.c:109:17: warning: too many arguments for format [-Wformat-extra-args]
                 msg, nitems, size, lineno);
                 ^
```

This change expands the logging to record the line number argument.
The message could be logged too, but might be long, so I have included
the ellipse in the message to indicate there is another argument to
calloc not being recorded.